### PR TITLE
Deprecate the use of precedence ordering?

### DIFF
--- a/ipware/defaults.py
+++ b/ipware/defaults.py
@@ -1,6 +1,13 @@
 from django.conf import settings
 
 
+# Header that proxy servers for this Django instance
+# are configured to send to convey the IP address of
+# the client issuing the request.
+IPWARE_META_IP_ADDRESS_HEADER = getattr(settings,
+    'IPWARE_META_IP_ADDRESS_HEADER', None
+)
+
 # Search for the real IP address in the following order
 # Configurable via settings.py
 IPWARE_META_PRECEDENCE_ORDER = getattr(settings,

--- a/ipware/defaults.py
+++ b/ipware/defaults.py
@@ -2,8 +2,8 @@ from django.conf import settings
 
 
 # Header that proxy servers for this Django instance
-# are configured to send to convey the IP address of
-# the client issuing the request.
+# use to convey the IP address of the client issuing
+# the request.
 IPWARE_META_IP_ADDRESS_HEADER = getattr(settings,
     'IPWARE_META_IP_ADDRESS_HEADER', None
 )

--- a/ipware/defaults.py
+++ b/ipware/defaults.py
@@ -4,9 +4,7 @@ from django.conf import settings
 # Header that proxy servers for this Django instance
 # use to convey the IP address of the client issuing
 # the request.
-IPWARE_META_IP_ADDRESS_HEADER = getattr(settings,
-    'IPWARE_META_IP_ADDRESS_HEADER', None
-)
+IPWARE_META_IP_ADDRESS_HEADER = getattr(settings, 'IPWARE_META_IP_ADDRESS_HEADER', None)
 
 # Search for the real IP address in the following order
 # Configurable via settings.py

--- a/ipware/ip.py
+++ b/ipware/ip.py
@@ -94,9 +94,9 @@ def get_ip(request, real_ip_only=False, right_most_proxy=False):
                       "To avoid this warning, set IPWARE_META_IP_ADDRESS_HEADER "
                       "to a header forwarded by trusted proxies.",
                       DeprecationWarning)
-        return _get_ip_using_precedence_order(request, real_ip_only, right_most_proxy=right_most_proxy)
+        return _get_ip_using_precedence_order(request, real_ip_only, right_most_proxy)
     else:
-        return _get_ip_using_ip_address_header(request, real_ip_only, right_most_proxy=right_most_proxy)
+        return _get_ip_using_ip_address_header(request, real_ip_only, right_most_proxy)
 
 
 def get_real_ip(request, right_most_proxy=False):

--- a/ipware/ip.py
+++ b/ipware/ip.py
@@ -1,33 +1,80 @@
 
 from .utils import is_valid_ip
+from .defaults import IPWARE_META_IP_ADDRESS_HEADER
 from .defaults import IPWARE_META_PRECEDENCE_ORDER
 from .defaults import IPWARE_NON_PUBLIC_IP_PREFIX
 
+import warnings
 
-def get_ip(request, real_ip_only=False):
+
+def _get_ip_from_header_value(value, real_ip_only=False, best_matched_ip=None):
     """
-    Returns client's best-matched ip-address, or None
+    Scans `value` and returns a two-tuple with an IP and a boolean to express whether or not the IP is real.
+
+    The tuple takes the form: ({IP_ADDRESS}, {IS_REAL})
+
+    The returned IP may be `None` if no good candidate IPs are found in `value`.
+
+    If `real_ip_only` is `False`, good candidate IPs include any well-formed IP. Otherwise,
+    good candidate IPs must be external, non-loopback IPs.
+
+    :param value: HTTP header value that contains a chain of IP addresses
+    :param real_ip_only: when `True`, this function only returns external, non-loopback IPs
+    :param best_matched_ip: an already-discovered IP that corresponds to the request. Returned
+                            in the two-tuple unless a better match is found
+    :returns: a two-tuple with the IP address and a boolean to express whether or not the IP is real
     """
+    assert value != '', "Empty value passed to function."
+
+    ips = [ip.strip().lower() for ip in value.split(',')]
+    for ip_str in reversed(ips):
+        if ip_str and is_valid_ip(ip_str):
+            if not ip_str.startswith(IPWARE_NON_PUBLIC_IP_PREFIX):
+                return ip_str, True
+            elif not real_ip_only:
+                loopback = ('127.0.0.1', '::1')
+                if best_matched_ip is None:
+                    best_matched_ip = ip_str
+                elif best_matched_ip in loopback and ip_str not in loopback:
+                    best_matched_ip = ip_str
+
+    return best_matched_ip, False
+
+
+def _get_ip_using_ip_address_header(request, real_ip_only=False):
+    value = request.META.get(IPWARE_META_IP_ADDRESS_HEADER, '').strip()
+    if value != '':
+        return _get_ip_from_header_value(value)[0]
+    else:
+        return None
+
+
+def _get_ip_using_precedence_order(request, real_ip_only=False):
     best_matched_ip = None
     for key in IPWARE_META_PRECEDENCE_ORDER:
         value = request.META.get(key, '').strip()
         if value != '':
-            ips = [ip.strip().lower() for ip in value.split(',')]
-            for ip_str in reversed(ips):
-                if ip_str and is_valid_ip(ip_str):
-                    if not ip_str.startswith(IPWARE_NON_PUBLIC_IP_PREFIX):
-                        return ip_str
-                    elif not real_ip_only:
-                        loopback = ('127.0.0.1', '::1')
-                        if best_matched_ip is None:
-                            best_matched_ip = ip_str
-                        elif best_matched_ip in loopback and ip_str not in loopback:
-                            best_matched_ip = ip_str
+            header_ip, is_real_ip = _get_ip_from_header_value(value, real_ip_only, best_matched_ip)
+            if is_real_ip:
+                return header_ip
+            else:
+                best_matched_ip = header_ip
+
     return best_matched_ip
 
 
+def get_ip(request, real_ip_only=False):
+    """ Returns client's best-matched ip-address, or `None` """
+    if not IPWARE_META_IP_ADDRESS_HEADER:
+        warnings.warn("The use of header precedence ordering is deprecated. "
+                      "To avoid this warning, set IPWARE_META_IP_ADDRESS_HEADER "
+                      "to a header used by trusted proxies.",
+                      DeprecationWarning)
+        return _get_ip_using_precedence_order(request, real_ip_only)
+    else:
+        return _get_ip_using_ip_address_header(request, real_ip_only)
+
+
 def get_real_ip(request):
-    """
-    Returns client's best-matched `real` ip-address, or None
-    """
+    """ Returns client's best-matched `real` ip-address, or None """
     return get_ip(request, real_ip_only=True)

--- a/ipware/ip.py
+++ b/ipware/ip.py
@@ -13,7 +13,7 @@ def get_ip(request, real_ip_only=False):
         value = request.META.get(key, '').strip()
         if value != '':
             ips = [ip.strip().lower() for ip in value.split(',')]
-            for ip_str in ips:
+            for ip_str in reversed(ips):
                 if ip_str and is_valid_ip(ip_str):
                     if not ip_str.startswith(IPWARE_NON_PUBLIC_IP_PREFIX):
                         return ip_str

--- a/ipware/tests.py
+++ b/ipware/tests.py
@@ -2,6 +2,8 @@
 
 from django.http import HttpRequest
 from django.test import TestCase
+
+import ipware.ip as ipware_module
 from ipware.ip import get_real_ip, get_ip
 
 
@@ -317,3 +319,23 @@ class IPv6TestCase(TestCase):
         }
         ip = get_ip(request)
         self.assertEqual(ip, "fe80::02ba")
+
+
+class IPAddressHeaderTestCase(TestCase):
+    """IP address header test"""
+
+    def setUp(self):
+        ipware_module.IPWARE_META_IP_ADDRESS_HEADER = 'HTTP_X_REAL_IP'
+
+    def tearDown(self):
+        ipware_module.IPWARE_META_IP_ADDRESS_HEADER = None
+
+    def test_x_real_ip(self):
+        request = HttpRequest()
+        request.META = {
+            'HTTP_X_FORWARDED_FOR': '177.139.233.139',
+            'HTTP_X_REAL_IP': '177.139.233.132',
+            'REMOTE_ADDR': '177.139.233.133',
+        }
+        ip = get_real_ip(request)
+        self.assertEqual(ip, "177.139.233.132")

--- a/ipware/tests.py
+++ b/ipware/tests.py
@@ -16,12 +16,12 @@ class IPv4TestCase(TestCase):
             'REMOTE_ADDR': '177.139.233.133',
         }
         ip = get_real_ip(request)
-        self.assertEqual(ip, "198.84.193.157")
+        self.assertEqual(ip, "177.139.233.139")
 
     def test_x_forwarded_for_multiple_bad_address(self):
         request = HttpRequest()
         request.META = {
-            'HTTP_X_FORWARDED_FOR': 'unknown, 192.168.255.182, 10.0.0.0, 127.0.0.1, 198.84.193.157, 177.139.233.139',
+            'HTTP_X_FORWARDED_FOR': '177.139.233.139, 198.84.193.157, unknown, 192.168.255.182, 10.0.0.0, 127.0.0.1',
             'HTTP_X_REAL_IP': '177.139.233.132',
             'REMOTE_ADDR': '177.139.233.133',
         }
@@ -169,7 +169,7 @@ class IPv6TestCase(TestCase):
     def test_x_forwarded_for_multiple(self):
         request = HttpRequest()
         request.META = {
-            'HTTP_X_FORWARDED_FOR': '3ffe:1900:4545:3:200:f8ff:fe21:67cf, 74dc::02ba',
+            'HTTP_X_FORWARDED_FOR': '74dc::02ba, 3ffe:1900:4545:3:200:f8ff:fe21:67cf',
             'HTTP_X_REAL_IP': '74dc::02ba',
             'REMOTE_ADDR': '74dc::02ba',
         }


### PR DESCRIPTION
For security reasons, it seems like we should discourage using precedence ordering when determining a "real" IP address. For a given infrastructure, if more than one header is considered when determining the request IP, a malicious third party could easily IP-spoof by supplying an IP via an unused header higher up in the precedence ordering.

As implemented in this changeset, perhaps deprecation of precedence ordering in favor of a setting for singular IPs isn't the right answer, but if this package goes on to use precedence ordering, at the very least it seems like there ought to be a warning emitted to users who stick with the defaults.