### PR TITLE
Fixes issue #11 - No longer throws an exception if any meta key is None

### DIFF
--- a/ipware/ip.py
+++ b/ipware/ip.py
@@ -12,7 +12,7 @@ def get_ip(request, real_ip_only=False, right_most_proxy=False):
     best_matched_ip = None
     for key in defs.IPWARE_META_PRECEDENCE_ORDER:
         value = request.META.get(key, '').strip()
-        if value != '':
+        if value is not None and value != '':
             ips = [ip.strip().lower() for ip in value.split(',')]
             if right_most_proxy:
                 ips = reversed(ips)

--- a/ipware/tests/tests_ipv4.py
+++ b/ipware/tests/tests_ipv4.py
@@ -8,6 +8,13 @@ from ipware.ip import get_real_ip, get_ip
 class IPv4TestCase(TestCase):
     """IP address Test"""
 
+    def test_meta_none(self):
+        request = HttpRequest()
+        request.META = {
+        }
+        ip = get_real_ip(request)
+        self.assertIsNone(ip)
+
     def test_http_x_forwarded_for_multiple(self):
         request = HttpRequest()
         request.META = {


### PR DESCRIPTION
This checks whether any of the meta keys is None to prevent the following:

```
Traceback:
File "/Users/patrick/.virtualenvs/ib-cms/lib/python2.7/site-packages/django/core/handlers/base.py" in get_response
  132.                     response = wrapped_callback(request, *callback_args, **callback_kwargs)
File "/Users/patrick/.virtualenvs/ib-cms/lib/python2.7/site-packages/django/views/decorators/csrf.py" in wrapped_view
  58.         return view_func(*args, **kwargs)
File "/Users/patrick/Dev/ib-main/cms/views.py" in fallback_upload_view
  192.                 queue.client_ip = get_ip(request)
File "/Users/patrick/.virtualenvs/ib-cms/lib/python2.7/site-packages/ipware/ip.py" in get_ip
  14.         value = request.META.get(key, '').strip()

```