### PR TITLE
Fixed #22 get_trusted_ip fails with right_most_proxy

### DIFF
--- a/ipware/ip.py
+++ b/ipware/ip.py
@@ -46,10 +46,9 @@ def get_trusted_ip(request, right_most_proxy=False, trusted_proxies=TRUSTED_PROX
             value = request.META.get(key, request.META.get(key.replace('_', '-'), '')).strip()
             if value:
                 ips = [ip.strip().lower() for ip in value.split(',')]
-                count = len(ips)
-                if right_most_proxy and count > 1:
-                    ips = reversed(ips)
-                if count > 1:
+                if len(ips) > 1:
+                    if right_most_proxy:
+                        ips.reverse()
                     for proxy in trusted_proxies:
                         if proxy in ips[-1]:
                             return ips[0]

--- a/ipware/tests/tests_ipv4.py
+++ b/ipware/tests/tests_ipv4.py
@@ -342,6 +342,14 @@ class IPv4TrustedProxiesTestCase(TestCase):
         ip = get_trusted_ip(request, trusted_proxies=['177.139.233.139'])
         self.assertEqual(ip, "198.84.193.157")
 
+    def test_http_x_forwarded_for_single_proxy_with_right_most(self):
+        request = HttpRequest()
+        request.META = {
+            'HTTP_X_FORWARDED_FOR': '177.139.233.139, 177.139.200.139, 198.84.193.157',
+        }
+        ip = get_trusted_ip(request, right_most_proxy=True, trusted_proxies=['177.139.233.139'])
+        self.assertEqual(ip, "198.84.193.157")
+
     def test_http_x_forwarded_for_multi_proxy(self):
         request = HttpRequest()
         request.META = {


### PR DESCRIPTION
Fixed #22 get_trusted_ip fails with right_most_proxy.
Increased test coverage.