### PR TITLE
Add IPv4 multicast range and addresses from RFC 6890

### DIFF
--- a/ipware/defaults.py
+++ b/ipware/defaults.py
@@ -22,8 +22,10 @@ IPWARE_META_PRECEDENCE_ORDER = getattr(settings,
 # Private IP addresses
 # http://en.wikipedia.org/wiki/List_of_assigned_/8_IPv4_address_blocks
 # https://en.wikipedia.org/wiki/Reserved_IP_addresses
+# https://www.ietf.org/rfc/rfc1112.txt (IPv4 multicast)
 # http://www.ietf.org/rfc/rfc3330.txt (IPv4)
 # http://www.ietf.org/rfc/rfc5156.txt (IPv6)
+# https://www.ietf.org/rfc/rfc6890.txt
 # Regex would be ideal here, but this is keeping it simple
 # Configurable via settings.py
 IPWARE_PRIVATE_IP_PREFIX = getattr(settings,

--- a/ipware/defaults.py
+++ b/ipware/defaults.py
@@ -52,10 +52,15 @@ IPWARE_PRIVATE_IP_PREFIX = getattr(settings,
         '198.18.', '198.19.',  # reserved for inter-network communications between two separate subnets
         '198.51.100.',  # reserved for documentation and example code
         '203.0.113.',  # reserved for documentation and example code
-        '255.255.255.',  # reserved for broadcast
+        '224.', '225.', '226.', '227.', '228.', '229.', '230.', '231.', '232.',
+        '233.', '234.', '235.', '236.', '237.', '238.', '239.', # multicast
+        '240.', '241.', '242.', '243.', '244.', '245.', '246.', '247.', '248.',
+        '249.', '250.', '251.', '252.', '253.', '254.', '255.', # reserved
     ) + (
         '::',  # Unspecified address
         '::ffff:', '2001:10:', '2001:20:'  # messages to software
+        '2001::', # TEREDO
+        '2001:2::', # benchmarking
         '2001:db8:',  # reserved for documentation and example code
         'fc00:',  # IPv6 private block
         'fe80:',  # link-local unicast

--- a/ipware/defaults.py
+++ b/ipware/defaults.py
@@ -53,14 +53,14 @@ IPWARE_PRIVATE_IP_PREFIX = getattr(settings,
         '198.51.100.',  # reserved for documentation and example code
         '203.0.113.',  # reserved for documentation and example code
         '224.', '225.', '226.', '227.', '228.', '229.', '230.', '231.', '232.',
-        '233.', '234.', '235.', '236.', '237.', '238.', '239.', # multicast
+        '233.', '234.', '235.', '236.', '237.', '238.', '239.',  # multicast
         '240.', '241.', '242.', '243.', '244.', '245.', '246.', '247.', '248.',
-        '249.', '250.', '251.', '252.', '253.', '254.', '255.', # reserved
+        '249.', '250.', '251.', '252.', '253.', '254.', '255.',  # reserved
     ) + (
         '::',  # Unspecified address
         '::ffff:', '2001:10:', '2001:20:'  # messages to software
-        '2001::', # TEREDO
-        '2001:2::', # benchmarking
+        '2001::',  # TEREDO
+        '2001:2::',  # benchmarking
         '2001:db8:',  # reserved for documentation and example code
         'fc00:',  # IPv6 private block
         'fe80:',  # link-local unicast


### PR DESCRIPTION
IPv4 multicast host group addresses are not valid source addresses per [RFC1112]: 

> A host group address must never be placed in the source address field

The 240.0.0.0/4 block is "reserved for future use", and not globally routable [RFC6890].

Also added 2001::/32 and 2001:2::/48 which are not global per [RFC6890].

[RFC1112] https://tools.ietf.org/html/rfc1112
[RFC6890] https://tools.ietf.org/html/rfc6890