### PR TITLE
ipware: Adjust Forwarded handling to match RFC 7239

### DIFF
--- a/ipware/ip2.py
+++ b/ipware/ip2.py
@@ -24,7 +24,10 @@ def get_client_ip(
     for key in request_header_order:
         value = util.get_request_meta(request, key)
         if value:
-            ips, ip_count = util.get_ips_from_string(value)
+            if key == 'HTTP_FORWARDED':
+                ips, ip_count = util.get_ips_from_forwarded_string(value)
+            else:
+                ips, ip_count = util.get_ips_from_string(value)
 
             if ip_count < 1:
                 # we are expecting at least one IP address to process

--- a/ipware/tests/tests_ipv6.py
+++ b/ipware/tests/tests_ipv6.py
@@ -171,3 +171,19 @@ class IPv4TestCase(TestCase):
         }
         result = get_client_ip(request, proxy_count=1, proxy_trusted_ips=['74dc::02bb'])
         self.assertEqual(result, (None, False))
+
+    def test_forwarded(self):
+        request = HttpRequest()
+        request.META = {
+            'HTTP_FORWARDED': 'for="[2001:db8:cafe::17]", for=unknown"',
+        }
+        result = get_client_ip(request)
+        self.assertEqual(result, ('2001:db8:cafe::17', True))
+
+    def test_forwarded_with_port(self):
+        request = HttpRequest()
+        request.META = {
+            'HTTP_FORWARDED': 'for="[2001:db8:cafe::17]:4711"',
+        }
+        result = get_client_ip(request)
+        self.assertEqual(result, ('2001:db8:cafe::17', True))

--- a/ipware/utils.py
+++ b/ipware/utils.py
@@ -1,3 +1,4 @@
+import email.utils
 import socket
 
 from . import defaults as defs
@@ -86,6 +87,94 @@ def get_ips_from_string(ip_str):
             return ip_list, ip_count
 
     return [], 0
+
+
+def _parse_node_identifier(node):
+    """
+    Parse RFC 7239's node.
+
+    https://tools.ietf.org/html/rfc7239#section-6
+    """
+    values = {}
+    elements = node.rsplit(':', 1)
+    if len(elements) == 2 and ']' in elements[1]:
+        elements = [node]  # don't split inside IPv6
+    values['name'] = elements[0]
+    if len(elements) == 2:
+        if elements[1].startswith('_'):  # obfport
+            values['port'] = elements[1]
+        else:
+            values['port'] = int(elements[1])
+    return values
+
+
+def _parse_forwarded_pair(forwarded_pair):
+    """
+    Parse RFC 7239's forwarded-pair.
+
+    https://tools.ietf.org/html/rfc7239#section-4
+    """
+    key, value = ''.join(forwarded_pair).split('=', 1)
+    key = key.lower()
+    value = email.utils.unquote(value)
+    if key == 'for':
+        return key, _parse_node_identifier(node=value)
+    else:
+        return key, value
+
+
+def _parse_http_list(list, delimiter=','):
+    """
+    Split a list where the entries may contain quoted strings.
+
+    The list extention [1] and quoted-string [2] are defined in RFC
+    7230.  The delimiter defaults to ',', which matches [1].
+
+    You can override the delimiter to parse structures like RFC 7239's
+    forwarded-element into forwarded-pairs [3], in which case you
+    would set delimiter=';'.
+
+    [1]: https://tools.ietf.org/html/rfc7230#section-7
+    [2]: https://tools.ietf.org/html/rfc7230#section-3.2.6
+    [3]: https://tools.ietf.org/html/rfc7239#section-4
+    """
+    entry = []
+    in_escape = in_quote = False
+    for char in list:
+        if char == '\\' and in_quote:
+            in_escape = not in_escape
+        elif in_escape:
+            in_escape = False
+        elif char == '"':
+            in_quote = not in_quote
+        if char == delimiter and not in_quote:
+            yield ''.join(entry).strip()
+            entry = []
+        else:
+            entry.append(char)
+    if entry:
+        yield ''.join(entry).strip()
+
+
+def get_ips_from_forwarded_string(ip_str):
+    """
+    Given a string, it returns a list of one or more valid IP addresses
+    """
+    ip_list = []
+
+    for forwarded_element in _parse_http_list(ip_str, delimiter=','):
+        for pair in _parse_http_list(forwarded_element, delimiter=';'):
+            key, value = _parse_forwarded_pair(forwarded_pair=''.join(pair))
+            if key == 'for':
+                name = value['name']
+                if name.startswith('['):  # IPv6
+                    name = name.lstrip('[').rstrip(']')
+                ip_list.append(name)
+
+    ip_count = len(ip_list)
+    if ip_count == 0:
+        raise ValueError('at least one forwarded-element is required')
+    return ip_list, ip_count
 
 
 def get_ip_info(ip_str):


### PR DESCRIPTION
[RFC 7239][1] defines the `Forwarded` header, which is not just a comma-separated list of IP addresses (which is how ipware has treated the header since it started watching it in e30af18f).  This commit adds support for the RFC form using [`email.utils.unquote`][3] (also [in Python 2][2]) and an HTTP-list parser.  I'd intially used the [undocumented `parse_http_list`][4], but it [incorrectly strips backslashes][5].

The example values I've used in the tests are mostly from (or excerpted from) [the RFC][1].

[1]: https://tools.ietf.org/html/rfc7239
[2]: https://docs.python.org/2/library/email.util.html#email.utils.unquote
[3]: https://docs.python.org/3/library/email.util.html#email.utils.unquote
[4]: https://bugs.python.org/issue33003
[5]: https://bugs.python.org/issue33008