### PR TITLE
Get settings in runtime instead of import time

### DIFF
--- a/ipware/defaults.py
+++ b/ipware/defaults.py
@@ -5,18 +5,16 @@ from django.conf import settings
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For
 # X-Forwarded-For: <client>, <proxy1>, <proxy2>
 # Configurable via settings.py
-IPWARE_META_PRECEDENCE_ORDER = getattr(settings,
-    'IPWARE_META_PRECEDENCE_ORDER', (
-        'HTTP_X_FORWARDED_FOR', 'X_FORWARDED_FOR',
-        'HTTP_CLIENT_IP',
-        'HTTP_X_REAL_IP',
-        'HTTP_X_FORWARDED',
-        'HTTP_X_CLUSTER_CLIENT_IP',
-        'HTTP_FORWARDED_FOR',
-        'HTTP_FORWARDED',
-        'HTTP_VIA',
-        'REMOTE_ADDR',
-    )
+DEFAULT_IPWARE_META_PRECEDENCE_ORDER = (
+    'HTTP_X_FORWARDED_FOR', 'X_FORWARDED_FOR',
+    'HTTP_CLIENT_IP',
+    'HTTP_X_REAL_IP',
+    'HTTP_X_FORWARDED',
+    'HTTP_X_CLUSTER_CLIENT_IP',
+    'HTTP_FORWARDED_FOR',
+    'HTTP_FORWARDED',
+    'HTTP_VIA',
+    'REMOTE_ADDR',
 )
 
 # Private IP addresses
@@ -28,51 +26,47 @@ IPWARE_META_PRECEDENCE_ORDER = getattr(settings,
 # https://www.ietf.org/rfc/rfc6890.txt
 # Regex would be ideal here, but this is keeping it simple
 # Configurable via settings.py
-IPWARE_PRIVATE_IP_PREFIX = getattr(settings,
-    'IPWARE_PRIVATE_IP_PREFIX', (
-        '0.',  # messages to software
-        '10.',  # class A private block
-        '100.64.',  '100.65.',  '100.66.',  '100.67.',  '100.68.',  '100.69.',
-        '100.70.',  '100.71.',  '100.72.',  '100.73.',  '100.74.',  '100.75.',
-        '100.76.',  '100.77.',  '100.78.',  '100.79.',  '100.80.',  '100.81.',
-        '100.82.',  '100.83.',  '100.84.',  '100.85.',  '100.86.',  '100.87.',
-        '100.88.',  '100.89.',  '100.90.',  '100.91.',  '100.92.',  '100.93.',
-        '100.94.',  '100.95.',  '100.96.',  '100.97.',  '100.98.',  '100.99.',
-        '100.100.', '100.101.', '100.102.', '100.103.', '100.104.', '100.105.',
-        '100.106.', '100.107.', '100.108.', '100.109.', '100.110.', '100.111.',
-        '100.112.', '100.113.', '100.114.', '100.115.', '100.116.', '100.117.',
-        '100.118.', '100.119.', '100.120.', '100.121.', '100.122.', '100.123.',
-        '100.124.', '100.125.', '100.126.', '100.127.',  # carrier-grade NAT
-        '169.254.',  # link-local block
-        '172.16.', '172.17.', '172.18.', '172.19.',
-        '172.20.', '172.21.', '172.22.', '172.23.',
-        '172.24.', '172.25.', '172.26.', '172.27.',
-        '172.28.', '172.29.', '172.30.', '172.31.',  # class B private blocks
-        '192.0.0.',  # reserved for IANA special purpose address registry
-        '192.0.2.',  # reserved for documentation and example code
-        '192.168.',  # class C private block
-        '198.18.', '198.19.',  # reserved for inter-network communications between two separate subnets
-        '198.51.100.',  # reserved for documentation and example code
-        '203.0.113.',  # reserved for documentation and example code
-        '224.', '225.', '226.', '227.', '228.', '229.', '230.', '231.', '232.',
-        '233.', '234.', '235.', '236.', '237.', '238.', '239.',  # multicast
-        '240.', '241.', '242.', '243.', '244.', '245.', '246.', '247.', '248.',
-        '249.', '250.', '251.', '252.', '253.', '254.', '255.',  # reserved
-    ) + (
-        '::',  # Unspecified address
-        '::ffff:', '2001:10:', '2001:20:'  # messages to software
-        '2001::',  # TEREDO
-        '2001:2::',  # benchmarking
-        '2001:db8:',  # reserved for documentation and example code
-        'fc00:',  # IPv6 private block
-        'fe80:',  # link-local unicast
-        'ff00:',  # IPv6 multicast
-    )
+DEFAULT_IPWARE_PRIVATE_IP_PREFIX = (
+    '0.',  # messages to software
+    '10.',  # class A private block
+    '100.64.',  '100.65.',  '100.66.',  '100.67.',  '100.68.',  '100.69.',
+    '100.70.',  '100.71.',  '100.72.',  '100.73.',  '100.74.',  '100.75.',
+    '100.76.',  '100.77.',  '100.78.',  '100.79.',  '100.80.',  '100.81.',
+    '100.82.',  '100.83.',  '100.84.',  '100.85.',  '100.86.',  '100.87.',
+    '100.88.',  '100.89.',  '100.90.',  '100.91.',  '100.92.',  '100.93.',
+    '100.94.',  '100.95.',  '100.96.',  '100.97.',  '100.98.',  '100.99.',
+    '100.100.', '100.101.', '100.102.', '100.103.', '100.104.', '100.105.',
+    '100.106.', '100.107.', '100.108.', '100.109.', '100.110.', '100.111.',
+    '100.112.', '100.113.', '100.114.', '100.115.', '100.116.', '100.117.',
+    '100.118.', '100.119.', '100.120.', '100.121.', '100.122.', '100.123.',
+    '100.124.', '100.125.', '100.126.', '100.127.',  # carrier-grade NAT
+    '169.254.',  # link-local block
+    '172.16.', '172.17.', '172.18.', '172.19.',
+    '172.20.', '172.21.', '172.22.', '172.23.',
+    '172.24.', '172.25.', '172.26.', '172.27.',
+    '172.28.', '172.29.', '172.30.', '172.31.',  # class B private blocks
+    '192.0.0.',  # reserved for IANA special purpose address registry
+    '192.0.2.',  # reserved for documentation and example code
+    '192.168.',  # class C private block
+    '198.18.', '198.19.',  # reserved for inter-network communications between two separate subnets
+    '198.51.100.',  # reserved for documentation and example code
+    '203.0.113.',  # reserved for documentation and example code
+    '224.', '225.', '226.', '227.', '228.', '229.', '230.', '231.', '232.',
+    '233.', '234.', '235.', '236.', '237.', '238.', '239.',  # multicast
+    '240.', '241.', '242.', '243.', '244.', '245.', '246.', '247.', '248.',
+    '249.', '250.', '251.', '252.', '253.', '254.', '255.',  # reserved
+) + (
+    '::',  # Unspecified address
+    '::ffff:', '2001:10:', '2001:20:'  # messages to software
+    '2001::',  # TEREDO
+    '2001:2::',  # benchmarking
+    '2001:db8:',  # reserved for documentation and example code
+    'fc00:',  # IPv6 private block
+    'fe80:',  # link-local unicast
+    'ff00:',  # IPv6 multicast
 )
 
-IPWARE_LOOPBACK_PREFIX = (
+DEFAULT_IPWARE_LOOPBACK_PREFIX = (
     '127.',  # IPv4 loopback device (Host)
     '::1',  # IPv6 loopback device (Host)
 )
-
-IPWARE_NON_PUBLIC_IP_PREFIX = IPWARE_PRIVATE_IP_PREFIX + IPWARE_LOOPBACK_PREFIX

--- a/ipware/ip.py
+++ b/ipware/ip.py
@@ -1,9 +1,9 @@
 from django.conf import settings
 
-from .utils import is_valid_ip
+from .utils import is_valid_ip, get_non_public_ip_prefixes
 from . import defaults as defs
 
-NON_PUBLIC_IP_PREFIX = tuple([ip.lower() for ip in defs.IPWARE_NON_PUBLIC_IP_PREFIX])
+NON_PUBLIC_IP_PREFIX = tuple([ip.lower() for ip in get_non_public_ip_prefixes()])
 TRUSTED_PROXY_LIST = tuple([ip.lower() for ip in getattr(settings, 'IPWARE_TRUSTED_PROXY_LIST', [])])
 
 
@@ -13,7 +13,7 @@ def get_ip(request, real_ip_only=False, right_most_proxy=False):
     @deprecated - Do not edit
     """
     best_matched_ip = None
-    for key in defs.IPWARE_META_PRECEDENCE_ORDER:
+    for key in getattr(settings, 'IPWARE_META_PRECEDENCE_ORDER', defs.DEFAULT_IPWARE_META_PRECEDENCE_ORDER):
         value = request.META.get(key, request.META.get(key.replace('_', '-'), '')).strip()
         if value is not None and value != '':
             ips = [ip.strip().lower() for ip in value.split(',')]
@@ -24,7 +24,7 @@ def get_ip(request, real_ip_only=False, right_most_proxy=False):
                     if not ip_str.startswith(NON_PUBLIC_IP_PREFIX):
                         return ip_str
                     if not real_ip_only:
-                        loopback = defs.IPWARE_LOOPBACK_PREFIX
+                        loopback = getattr(settings, 'IPWARE_LOOPBACK_PREFIX', defs.DEFAULT_IPWARE_LOOPBACK_PREFIX)
                         if best_matched_ip is None:
                             best_matched_ip = ip_str
                         elif best_matched_ip.startswith(loopback) and not ip_str.startswith(loopback):

--- a/ipware/ip2.py
+++ b/ipware/ip2.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from . import utils as util
 from . import defaults as defs
 
@@ -19,7 +20,7 @@ def get_client_ip(
         proxy_trusted_ips = []
 
     if request_header_order is None:
-        request_header_order = defs.IPWARE_META_PRECEDENCE_ORDER
+        request_header_order = getattr(settings, 'IPWARE_META_PRECEDENCE_ORDER', defs.DEFAULT_IPWARE_META_PRECEDENCE_ORDER)
 
     for key in request_header_order:
         value = util.get_request_meta(request, key)

--- a/ipware/tests/tests_ipv4.py
+++ b/ipware/tests/tests_ipv4.py
@@ -251,3 +251,16 @@ class IPv4TestCase(TestCase):
         }
         ip = get_client_ip(request, request_header_order=['X_FORWARDED_FOR', 'HTTP_X_FORWARDED_FOR'])
         self.assertEqual(ip, ("177.139.233.138", True))
+
+    def test_setting_override(self):
+        request = HttpRequest()
+        request.META = {
+            'HTTP_X_FORWARDED_FOR': '177.139.233.139, 198.84.193.157, 198.84.193.158',
+            'REMOTE_ADDR': '177.139.233.133',
+        }
+        with self.settings(IPWARE_META_PRECEDENCE_ORDER=(
+                'REMOTE_ADDR',
+                'HTTP_X_FORWARDED_FOR', 'X_FORWARDED_FOR',
+            )):
+            result = get_client_ip(request)
+            self.assertEqual(result, ("177.139.233.133", True))

--- a/ipware/utils.py
+++ b/ipware/utils.py
@@ -1,7 +1,14 @@
 import socket
 
+from django.conf import settings
 from . import defaults as defs
 
+
+def get_non_public_ip_prefixes():
+    return getattr(settings, 'IPWARE_NON_PUBLIC_IP_PREFIX', 
+        getattr(settings, 'IPWARE_PRIVATE_IP_PREFIX', defs.DEFAULT_IPWARE_PRIVATE_IP_PREFIX) +
+        getattr(settings, 'IPWARE_LOOPBACK_PREFIX', defs.DEFAULT_IPWARE_LOOPBACK_PREFIX)
+    )
 
 def is_valid_ipv4(ip_str):
     """
@@ -42,7 +49,7 @@ def is_private_ip(ip_str):
     """
     Returns true of ip_str is private & not routable, else return false
     """
-    return ip_str.startswith(defs.IPWARE_NON_PUBLIC_IP_PREFIX)
+    return ip_str.startswith(getattr(settings, 'IPWARE_NON_PUBLIC_IP_PREFIX', get_non_public_ip_prefixes()))
 
 
 def is_public_ip(ip_str):
@@ -56,7 +63,7 @@ def is_loopback_ip(ip_str):
     """
     Returns true of ip_str is public & routable, else return false
     """
-    return ip_str.startswith(defs.IPWARE_LOOPBACK_PREFIX)
+    return ip_str.startswith(getattr(settings, 'IPWARE_LOOPBACK_PREFIX', defs.DEFAULT_IPWARE_LOOPBACK_PREFIX))
 
 
 def get_request_meta(request, key):

--- a/ipware/utils.py
+++ b/ipware/utils.py
@@ -5,10 +5,10 @@ from . import defaults as defs
 
 
 def get_non_public_ip_prefixes():
-    return getattr(settings, 'IPWARE_NON_PUBLIC_IP_PREFIX', 
-        getattr(settings, 'IPWARE_PRIVATE_IP_PREFIX', defs.DEFAULT_IPWARE_PRIVATE_IP_PREFIX) +
-        getattr(settings, 'IPWARE_LOOPBACK_PREFIX', defs.DEFAULT_IPWARE_LOOPBACK_PREFIX)
+    return getattr(settings, 'IPWARE_NON_PUBLIC_IP_PREFIX',
+        getattr(settings, 'IPWARE_PRIVATE_IP_PREFIX', defs.DEFAULT_IPWARE_PRIVATE_IP_PREFIX) + getattr(settings, 'IPWARE_LOOPBACK_PREFIX', defs.DEFAULT_IPWARE_LOOPBACK_PREFIX)
     )
+
 
 def is_valid_ipv4(ip_str):
     """


### PR DESCRIPTION
With import-time configuration it's not possible to change the settings with the Django's built-in settings override method in tests.
Now I'm able to write
```
def testNoIp(self):
    with self.settings(IPWARE_META_PRECEDENCE_ORDER=()):
    # ...
```
