### PR TITLE
Allow central configuration of trusted proxy behaviour by adding them to settings.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 3.0.1
 
+Enhancement:
+  - Change how settings are handled so that `override_settings` will work in tests to influence ipware configuration.
 Fix:
   - Ensure no-required build artifacts won't get into the package 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Enhancement:
   - Change how settings are handled so that `override_settings` will work in tests to influence ipware configuration.
+  - Add `IPWARE_PROXY_ORDER`, `IPWARE_PROXY_COUNT` and `IPWARE_PROXY_TRUSTED_IPS` to Django settings, which are used when the corresponding options are `None` or not supplied to `get_client_ip`.
 Fix:
   - Ensure no-required build artifacts won't get into the package 
 

--- a/ipware/apps.py
+++ b/ipware/apps.py
@@ -1,6 +1,7 @@
 from django.apps import AppConfig
 from django.utils.translation import ugettext_lazy as _
-
+from django.conf import settings
+from . import defaults
 
 class IPwareConfig(AppConfig):
     """
@@ -8,3 +9,22 @@ class IPwareConfig(AppConfig):
     """
     label = name = 'ipware'
     verbose_name = _("ipware app")
+
+    def ready(self):
+        # Copy all default attrs into the user's settings module if
+        # they're not defined there.
+        for attr in ('IPWARE_META_PRECEDENCE_ORDER', 'IPWARE_PRIVATE_IP_PREFIX', 'IPWARE_LOOPBACK_PREFIX'):
+            default_value = getattr(defaults, attr)
+            setattr(settings, attr, getattr(settings, attr, default_value))
+
+        # A bit hacky, ensure we always append standard prefixes
+        settings.IPWARE_PRIVATE_IP_PREFIX = tuple(settings.IPWARE_PRIVATE_IP_PREFIX) + (
+            '::',  # Unspecified address
+            '::ffff:', '2001:10:', '2001:20:'  # messages to software
+            '2001::',  # TEREDO
+            '2001:2::',  # benchmarking
+            '2001:db8:',  # reserved for documentation and example code
+            'fc00:',  # IPv6 private block
+            'fe80:',  # link-local unicast
+            'ff00:',  # IPv6 multicast
+        )

--- a/ipware/apps.py
+++ b/ipware/apps.py
@@ -13,7 +13,14 @@ class IPwareConfig(AppConfig):
     def ready(self):
         # Copy all default attrs into the user's settings module if
         # they're not defined there.
-        for attr in ('IPWARE_META_PRECEDENCE_ORDER', 'IPWARE_PRIVATE_IP_PREFIX', 'IPWARE_LOOPBACK_PREFIX'):
+        for attr in (
+                'IPWARE_META_PRECEDENCE_ORDER',
+                'IPWARE_PRIVATE_IP_PREFIX',
+                'IPWARE_LOOPBACK_PREFIX',
+                'IPWARE_PROXY_ORDER',
+                'IPWARE_PROXY_COUNT',
+                'IPWARE_PROXY_TRUSTED_IPS',
+        ):
             default_value = getattr(defaults, attr)
             setattr(settings, attr, getattr(settings, attr, default_value))
 

--- a/ipware/defaults.py
+++ b/ipware/defaults.py
@@ -61,3 +61,7 @@ IPWARE_LOOPBACK_PREFIX = (
     '127.',  # IPv4 loopback device (Host)
     '::1',  # IPv6 loopback device (Host)
 )
+
+IPWARE_PROXY_ORDER='left-most'
+IPWARE_PROXY_COUNT=None
+IPWARE_PROXY_TRUSTED_IPS=None

--- a/ipware/defaults.py
+++ b/ipware/defaults.py
@@ -1,22 +1,20 @@
-from django.conf import settings
-
+# Default settings, are injected into user settings.py through the
+# ready callback in AppConfig.
 
 # Search for the real IP address in the following order
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For
 # X-Forwarded-For: <client>, <proxy1>, <proxy2>
 # Configurable via settings.py
-IPWARE_META_PRECEDENCE_ORDER = getattr(settings,
-    'IPWARE_META_PRECEDENCE_ORDER', (
-        'HTTP_X_FORWARDED_FOR', 'X_FORWARDED_FOR',
-        'HTTP_CLIENT_IP',
-        'HTTP_X_REAL_IP',
-        'HTTP_X_FORWARDED',
-        'HTTP_X_CLUSTER_CLIENT_IP',
-        'HTTP_FORWARDED_FOR',
-        'HTTP_FORWARDED',
-        'HTTP_VIA',
-        'REMOTE_ADDR',
-    )
+IPWARE_META_PRECEDENCE_ORDER = (
+    'HTTP_X_FORWARDED_FOR', 'X_FORWARDED_FOR',
+    'HTTP_CLIENT_IP',
+    'HTTP_X_REAL_IP',
+    'HTTP_X_FORWARDED',
+    'HTTP_X_CLUSTER_CLIENT_IP',
+    'HTTP_FORWARDED_FOR',
+    'HTTP_FORWARDED',
+    'HTTP_VIA',
+    'REMOTE_ADDR',
 )
 
 # Private IP addresses
@@ -28,51 +26,38 @@ IPWARE_META_PRECEDENCE_ORDER = getattr(settings,
 # https://www.ietf.org/rfc/rfc6890.txt
 # Regex would be ideal here, but this is keeping it simple
 # Configurable via settings.py
-IPWARE_PRIVATE_IP_PREFIX = getattr(settings,
-    'IPWARE_PRIVATE_IP_PREFIX', (
-        '0.',  # messages to software
-        '10.',  # class A private block
-        '100.64.',  '100.65.',  '100.66.',  '100.67.',  '100.68.',  '100.69.',
-        '100.70.',  '100.71.',  '100.72.',  '100.73.',  '100.74.',  '100.75.',
-        '100.76.',  '100.77.',  '100.78.',  '100.79.',  '100.80.',  '100.81.',
-        '100.82.',  '100.83.',  '100.84.',  '100.85.',  '100.86.',  '100.87.',
-        '100.88.',  '100.89.',  '100.90.',  '100.91.',  '100.92.',  '100.93.',
-        '100.94.',  '100.95.',  '100.96.',  '100.97.',  '100.98.',  '100.99.',
-        '100.100.', '100.101.', '100.102.', '100.103.', '100.104.', '100.105.',
-        '100.106.', '100.107.', '100.108.', '100.109.', '100.110.', '100.111.',
-        '100.112.', '100.113.', '100.114.', '100.115.', '100.116.', '100.117.',
-        '100.118.', '100.119.', '100.120.', '100.121.', '100.122.', '100.123.',
-        '100.124.', '100.125.', '100.126.', '100.127.',  # carrier-grade NAT
-        '169.254.',  # link-local block
-        '172.16.', '172.17.', '172.18.', '172.19.',
-        '172.20.', '172.21.', '172.22.', '172.23.',
-        '172.24.', '172.25.', '172.26.', '172.27.',
-        '172.28.', '172.29.', '172.30.', '172.31.',  # class B private blocks
-        '192.0.0.',  # reserved for IANA special purpose address registry
-        '192.0.2.',  # reserved for documentation and example code
-        '192.168.',  # class C private block
-        '198.18.', '198.19.',  # reserved for inter-network communications between two separate subnets
-        '198.51.100.',  # reserved for documentation and example code
-        '203.0.113.',  # reserved for documentation and example code
-        '224.', '225.', '226.', '227.', '228.', '229.', '230.', '231.', '232.',
-        '233.', '234.', '235.', '236.', '237.', '238.', '239.',  # multicast
-        '240.', '241.', '242.', '243.', '244.', '245.', '246.', '247.', '248.',
-        '249.', '250.', '251.', '252.', '253.', '254.', '255.',  # reserved
-    ) + (
-        '::',  # Unspecified address
-        '::ffff:', '2001:10:', '2001:20:'  # messages to software
-        '2001::',  # TEREDO
-        '2001:2::',  # benchmarking
-        '2001:db8:',  # reserved for documentation and example code
-        'fc00:',  # IPv6 private block
-        'fe80:',  # link-local unicast
-        'ff00:',  # IPv6 multicast
-    )
+IPWARE_PRIVATE_IP_PREFIX = (
+    '0.',  # messages to software
+    '10.',  # class A private block
+    '100.64.',  '100.65.',  '100.66.',  '100.67.',  '100.68.',  '100.69.',
+    '100.70.',  '100.71.',  '100.72.',  '100.73.',  '100.74.',  '100.75.',
+    '100.76.',  '100.77.',  '100.78.',  '100.79.',  '100.80.',  '100.81.',
+    '100.82.',  '100.83.',  '100.84.',  '100.85.',  '100.86.',  '100.87.',
+    '100.88.',  '100.89.',  '100.90.',  '100.91.',  '100.92.',  '100.93.',
+    '100.94.',  '100.95.',  '100.96.',  '100.97.',  '100.98.',  '100.99.',
+    '100.100.', '100.101.', '100.102.', '100.103.', '100.104.', '100.105.',
+    '100.106.', '100.107.', '100.108.', '100.109.', '100.110.', '100.111.',
+    '100.112.', '100.113.', '100.114.', '100.115.', '100.116.', '100.117.',
+    '100.118.', '100.119.', '100.120.', '100.121.', '100.122.', '100.123.',
+    '100.124.', '100.125.', '100.126.', '100.127.',  # carrier-grade NAT
+    '169.254.',  # link-local block
+    '172.16.', '172.17.', '172.18.', '172.19.',
+    '172.20.', '172.21.', '172.22.', '172.23.',
+    '172.24.', '172.25.', '172.26.', '172.27.',
+    '172.28.', '172.29.', '172.30.', '172.31.',  # class B private blocks
+    '192.0.0.',  # reserved for IANA special purpose address registry
+    '192.0.2.',  # reserved for documentation and example code
+    '192.168.',  # class C private block
+    '198.18.', '198.19.',  # reserved for inter-network communications between two separate subnets
+    '198.51.100.',  # reserved for documentation and example code
+    '203.0.113.',  # reserved for documentation and example code
+    '224.', '225.', '226.', '227.', '228.', '229.', '230.', '231.', '232.',
+    '233.', '234.', '235.', '236.', '237.', '238.', '239.',  # multicast
+    '240.', '241.', '242.', '243.', '244.', '245.', '246.', '247.', '248.',
+    '249.', '250.', '251.', '252.', '253.', '254.', '255.',  # reserved
 )
 
 IPWARE_LOOPBACK_PREFIX = (
     '127.',  # IPv4 loopback device (Host)
     '::1',  # IPv6 loopback device (Host)
 )
-
-IPWARE_NON_PUBLIC_IP_PREFIX = IPWARE_PRIVATE_IP_PREFIX + IPWARE_LOOPBACK_PREFIX

--- a/ipware/ip.py
+++ b/ipware/ip.py
@@ -1,5 +1,5 @@
 from . import utils as util
-from . import defaults as defs
+from django.conf import settings
 
 
 def get_client_ip(
@@ -19,7 +19,7 @@ def get_client_ip(
         proxy_trusted_ips = []
 
     if request_header_order is None:
-        request_header_order = defs.IPWARE_META_PRECEDENCE_ORDER
+        request_header_order = settings.IPWARE_META_PRECEDENCE_ORDER
 
     for key in request_header_order:
         value = util.get_request_meta(request, key)

--- a/ipware/ip.py
+++ b/ipware/ip.py
@@ -4,7 +4,7 @@ from django.conf import settings
 
 def get_client_ip(
     request,
-    proxy_order='left-most',
+    proxy_order=None,
     proxy_count=None,
     proxy_trusted_ips=None,
     request_header_order=None,
@@ -13,13 +13,22 @@ def get_client_ip(
     routable = False
 
     if proxy_count is None:
+        proxy_count = settings.IPWARE_PROXY_COUNT
+
+    if proxy_count is None:
         proxy_count = -1
+
+    if proxy_trusted_ips is None:
+        proxy_trusted_ips = settings.IPWARE_PROXY_TRUSTED_IPS
 
     if proxy_trusted_ips is None:
         proxy_trusted_ips = []
 
     if request_header_order is None:
         request_header_order = settings.IPWARE_META_PRECEDENCE_ORDER
+
+    if proxy_order is None:
+        proxy_order = settings.IPWARE_PROXY_ORDER
 
     for key in request_header_order:
         value = util.get_request_meta(request, key)

--- a/ipware/tests/tests_common.py
+++ b/ipware/tests/tests_common.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from django.http import HttpRequest
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from .. import utils as util
 
 
@@ -30,12 +30,28 @@ class IPv4TestCase(TestCase):
         ip = '::1/128'
         self.assertTrue(util.is_private_ip(ip))
 
+    @override_settings(IPWARE_PRIVATE_IP_PREFIX=('177.', '3ffe:'), IPWARE_LOOPBACK_PREFIX=('111.', '8888:'))
+    def test_is_private_ip_uses_settings(self):
+        ip = '127.0.0.1'
+        self.assertFalse(util.is_private_ip(ip))
+
+        ip = '::1/128'
+        self.assertFalse(util.is_private_ip(ip))
+
     def test_is_public_ip(self):
         ip = '177.139.233.139'
         self.assertTrue(util.is_public_ip(ip))
 
         ip = '74dc::02ba'
         self.assertTrue(util.is_public_ip(ip))
+
+    @override_settings(IPWARE_PRIVATE_IP_PREFIX=('177.', '74dc:'), IPWARE_PUBLIC_IP_PREFIX=('127.', '1::'))
+    def test_is_public_ip_uses_settings(self):
+        ip = '177.139.233.139'
+        self.assertFalse(util.is_public_ip(ip))
+
+        ip = '74dc::02ba'
+        self.assertFalse(util.is_public_ip(ip))
 
     def test_is_loopback_ip(self):
         ip = '127.0.0.1'

--- a/ipware/tests/tests_ipv4.py
+++ b/ipware/tests/tests_ipv4.py
@@ -250,3 +250,17 @@ class IPv4TestCase(TestCase):
         }
         ip = get_client_ip(request, request_header_order=['X_FORWARDED_FOR', 'HTTP_X_FORWARDED_FOR'])
         self.assertEqual(ip, ("177.139.233.138", True))
+
+
+    def test_request_header_order_multiple_missing_or_none_takes_from_settings(self):
+        request = HttpRequest()
+        request.META = {
+            'HTTP_X_FORWARDED_FOR': '177.139.233.139, 198.84.193.157, 198.84.193.158',
+            'X_FORWARDED_FOR': '177.139.233.138, 198.84.193.157, 198.84.193.158',
+            'REMOTE_ADDR': '177.139.233.133',
+        }
+        with self.settings(IPWARE_META_PRECEDENCE_ORDER=['X_FORWARDED_FOR', 'HTTP_X_FORWARDED_FOR']):
+            ip = get_client_ip(request)
+            self.assertEqual(ip, ("177.139.233.138", True))
+            ip = get_client_ip(request, request_header_order=None)
+            self.assertEqual(ip, ("177.139.233.138", True))

--- a/ipware/utils.py
+++ b/ipware/utils.py
@@ -1,6 +1,5 @@
 import socket
-
-from . import defaults as defs
+from django.conf import settings
 
 
 def cleanup_ip(ip):
@@ -52,7 +51,12 @@ def is_private_ip(ip_str):
     """
     Returns true of ip_str is private & not routable, else return false
     """
-    return ip_str.startswith(defs.IPWARE_NON_PUBLIC_IP_PREFIX)
+    # TODO: Make this a setting?
+    IPWARE_NON_PUBLIC_IP_PREFIX = (
+        settings.IPWARE_PRIVATE_IP_PREFIX +
+        settings.IPWARE_LOOPBACK_PREFIX
+    )
+    return ip_str.startswith(IPWARE_NON_PUBLIC_IP_PREFIX)
 
 
 def is_public_ip(ip_str):
@@ -66,7 +70,7 @@ def is_loopback_ip(ip_str):
     """
     Returns true of ip_str is public & routable, else return false
     """
-    return ip_str.startswith(defs.IPWARE_LOOPBACK_PREFIX)
+    return ip_str.startswith(settings.IPWARE_LOOPBACK_PREFIX)
 
 
 def get_request_meta(request, key):


### PR DESCRIPTION
In a project of ours, we needed to use django-ipware, but the code itself was intended to be generic, so we couldn't hardcode the trusted proxy IP addresses in the calls to `get_client_ip()`. Instead of adding them to our project-specific `settings.py` and always passing them when calling `get_client_ip` I decided it would be a lot cleaner to add these settings to django-ipware, considering it already had settings for other things.

The behaviour should be backwards-compatible: if no settings are supplied for these values, the behaviour should be identical. If the settings are supplied but `get_client_ip` uses keyword arguments, those take precedence over the global settings.

I also restructured the code a little bit to make testing easier, as I wanted to make sure that the "fallback to settings" stuff works as designed by adding some tests; this also means user code can use `override_settings`, which wasn't working because Django isn't bootstrapped properly once the `ipware.defaults` module is loaded. So the first commit is a refactor to move the initialization of settings into `AppConfig.ready()`, and the second commit actually adds the new settings and tests for them.