### PR TITLE
Added ppc64le architecture support on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ python:
   - "3.5"
   - "pypy3"
 
+arch:
+  - amd64
+  - ppc64le
+
 env:
   - DJANGO="django==3.0.7"
   - DJANGO="django==2.2.8"
@@ -27,6 +31,9 @@ matrix:
   exclude:
     - python: "3.5"
       env: DJANGO="django==3.0.7"
+    - python: "pypy3"
+      arch: ppc64le
+
 
 script: coverage run --source=ipware manage.py test
 


### PR DESCRIPTION
Hi,
I had added ppc64le architecture support on travis-ci and looks like its been successfully added. Jobs depending on pypy3 on the ppc64le architecture are excluded as the feature pypy3 is not  supported on ppc64le yet. I believe it is ready for the final review and merge.

Please have a look.

Thanks!!
Kishor Kunal Raj
