### PR TITLE
Update python_requires to require 3.6+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup
 
 
 package = 'ipware'
-python_requires = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+python_requires = ">=3.6"
 here = os.path.abspath(os.path.dirname(__file__))
 
 requires = []


### PR DESCRIPTION
This matches what's defined in the classifiers.