### PR TITLE
Adding Azure Application Gateway support

### DIFF
--- a/docs/azure.md
+++ b/docs/azure.md
@@ -1,0 +1,18 @@
+# Azure Application Gateway
+
+If you use an Azure application gateways as a reverse proxy for your application the `HTTP_X_FORWARDED_FOR` header can be set using the IPv4 including a "random" port number - this for some reason does not happen on all requests.
+
+
+## Sample Headers
+
+```
+{
+    "REMOTE_ADDR": "192.168.50.44",
+    "HTTP_X_REAL_IP": "10.0.0.6",
+    "HTTP_X_FORWARDED_FOR": "177.139.233.139:17085, 10.0.0.6"
+}
+```
+
+## References
+
+* https://learn.microsoft.com/en-gb/azure/application-gateway/rewrite-http-headers-url#remove-port-information-from-the-x-forwarded-for-header

--- a/ipware/tests/tests_ipv4.py
+++ b/ipware/tests/tests_ipv4.py
@@ -23,6 +23,14 @@ class IPv4TestCase(TestCase):
         result = get_client_ip(request)
         self.assertEqual(result, ("177.139.233.139", True))
 
+    def test_meta_single_with_unwanted_port(self):
+        request = HttpRequest()
+        request.META = {
+            'HTTP_X_FORWARDED_FOR': '177.139.233.139:17085, 198.84.193.157, 198.84.193.158',
+        }
+        result = get_client_ip(request)
+        self.assertEqual(result, ("177.139.233.139", True))
+
     def test_meta_multi(self):
         request = HttpRequest()
         request.META = {

--- a/ipware/utils.py
+++ b/ipware/utils.py
@@ -3,11 +3,18 @@ import socket
 from . import defaults as defs
 
 
-def cleanup_ip(ip):
+def cleanup_ip(ip, strip_ports=True):
     """
-    Given ip address string, it cleans it up
+    Given ip address string, it cleans it up;
+
+    Args:
+        ip (str): ip address
+        strip_ports (bool, optional): Some reverse proxies add port numbers in the forward headers;
+                by default we remove them. Defaults to True.
     """
     ip = ip.strip().lower()
+    if ip.count(':') == 1 and strip_ports is True:
+        return ip.split(':')[0]
     if (ip.startswith('::ffff:')):
         return ip.replace('::ffff:', '')
     return ip
@@ -86,7 +93,7 @@ def get_ips_from_string(ip_str):
     ip_list = []
 
     for ip in ip_str.split(','):
-        clean_ip = ip.strip().lower()
+        clean_ip = cleanup_ip(ip)
         if clean_ip:
             ip_list.append(clean_ip)
 


### PR DESCRIPTION
# Azure Application Gateway support

If you use an Azure application gateways as a reverse proxy for your application the `HTTP_X_FORWARDED_FOR` header can be set using the IPv4 including a "random" port number - this for some reason does not happen on all requests.


## Sample Headers

logged on our instances; adopted IPs to test cases

```
{
    "REMOTE_ADDR": "192.168.50.44",
    "HTTP_X_REAL_IP": "10.0.0.6",
    "HTTP_X_FORWARDED_FOR": "177.139.233.139:17085, 10.0.0.6"
}
```

## References

* https://learn.microsoft.com/en-gb/azure/application-gateway/rewrite-http-headers-url#remove-port-information-from-the-x-forwarded-for-header