### PR TITLE
Attempt to strip ports from IPs

### DIFF
--- a/ipware/tests/tests_common.py
+++ b/ipware/tests/tests_common.py
@@ -68,6 +68,11 @@ class IPv4TestCase(TestCase):
         result = util.get_ips_from_string(ip_str)
         self.assertEqual(result, (['192.168.255.182', '198.84.193.157', '177.139.233.139'], 3))
 
+    def test_ips_with_port(self):
+        ip_str = "198.51.100.10:46532"
+        result = util.get_ips_from_string(ip_str)
+        self.assertEqual(result, (["198.51.100.10"], 1))
+
     def test_get_ip_info(self):
         ip = '127.0.0.1'
         result = util.get_ip_info(ip)

--- a/ipware/utils.py
+++ b/ipware/utils.py
@@ -1,5 +1,7 @@
 import socket
 
+from django.http.request import split_domain_port
+
 from . import defaults as defs
 
 
@@ -87,6 +89,12 @@ def get_ips_from_string(ip_str):
 
     for ip in ip_str.split(','):
         clean_ip = ip.strip().lower()
+
+        # Some IP values may contain a port
+        split_ip, port = split_domain_port(ip.strip().lower())
+        if port:
+            clean_ip = split_ip
+
         if clean_ip:
             ip_list.append(clean_ip)
 


### PR DESCRIPTION
Some IP headers, namely CloudFront's `CloudFront-Viewer-Address`, also contains the connecting port which needs to be stripped out.

See CloudFront's documentation: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-cloudfront-headers.html#cloudfront-headers-viewer-location