### PR TITLE
Use a regular assert instead of unittest-style

### DIFF
--- a/ipware/tests/tests_common.py
+++ b/ipware/tests/tests_common.py
@@ -12,72 +12,72 @@ class IPv4TestCase(TestCase):
 
     def test_is_valid_ip(self):
         ip = '177.139.233.139'
-        self.assertTrue(util.is_valid_ip(ip))
+        assert util.is_valid_ip(ip)
 
         ip = '3ffe:1900:4545:3:200:f8ff:fe21:67cf'
-        self.assertTrue(util.is_valid_ip(ip))
+        assert util.is_valid_ip(ip)
 
     def test_is_invalid_ip(self):
         ip = '177.139.233.139x'
-        self.assertFalse(util.is_valid_ip(ip))
+        assert not util.is_valid_ip(ip)
 
         ip = '3ffe:1900:4545:3:200:f8ff:fe21:67cz'
-        self.assertFalse(util.is_valid_ip(ip))
+        assert not util.is_valid_ip(ip)
 
     def test_is_private_ip(self):
         ip = '127.0.0.1'
-        self.assertTrue(util.is_private_ip(ip))
+        assert util.is_private_ip(ip)
 
         ip = '::1/128'
-        self.assertTrue(util.is_private_ip(ip))
+        assert util.is_private_ip(ip)
 
     def test_is_public_ip(self):
         ip = '177.139.233.139'
-        self.assertTrue(util.is_public_ip(ip))
+        assert util.is_public_ip(ip)
 
         ip = '74dc::02ba'
-        self.assertTrue(util.is_public_ip(ip))
+        assert util.is_public_ip(ip)
 
     def test_is_loopback_ip(self):
         ip = '127.0.0.1'
-        self.assertTrue(util.is_loopback_ip(ip))
+        assert util.is_loopback_ip(ip)
 
         ip = '177.139.233.139'
-        self.assertFalse(util.is_loopback_ip(ip))
+        assert not util.is_loopback_ip(ip)
 
         ip = '10.0.0.1'
-        self.assertFalse(util.is_loopback_ip(ip))
+        assert not util.is_loopback_ip(ip)
 
         ip = '::1/128'
-        self.assertTrue(util.is_loopback_ip(ip))
+        assert util.is_loopback_ip(ip)
 
         ip = '74dc::02ba'
-        self.assertFalse(util.is_loopback_ip(ip))
+        assert not util.is_loopback_ip(ip)
 
         ip = '2001:db8:'
-        self.assertFalse(util.is_loopback_ip(ip))
+        assert not util.is_loopback_ip(ip)
 
     def test_http_request_meta_headers(self):
         request = HttpRequest()
         ip_str = '192.168.255.182, 10.0.0.0, 127.0.0.1, 198.84.193.157, 177.139.233.139,'
         request.META = { 'HTTP_X_FORWARDED_FOR': ip_str }
         value = util.get_request_meta(request, 'HTTP_X_FORWARDED_FOR')
-        self.assertEqual(value, ip_str)
+        assert value == ip_str
 
     def test_ips_from_strings(self):
         ip_str = '192.168.255.182, 198.84.193.157, 177.139.233.139 ,'
         result = util.get_ips_from_string(ip_str)
-        self.assertEqual(result, (['192.168.255.182', '198.84.193.157', '177.139.233.139'], 3))
+        assert result == (['192.168.255.182', '198.84.193.157', '177.139.233.139'], 3)
 
     def test_get_ip_info(self):
         ip = '127.0.0.1'
         result = util.get_ip_info(ip)
-        self.assertTrue(result, (ip, False))
+        assert result, (ip, False)
 
         ip = '10.0.01'
         result = util.get_ip_info(ip)
-        self.assertTrue(result, (ip, False))
+        assert result, (ip, False)
 
         ip = '74dc::02ba'
         result = util.get_ip_info(ip)
-        self.assertTrue(result, (ip, True))
+        assert result, (ip, True)

--- a/ipware/tests/tests_ipv4.py
+++ b/ipware/tests/tests_ipv4.py
@@ -13,8 +13,8 @@ class IPv4TestCase(TestCase):
         request = HttpRequest()
         request.META = {}
         ip, routable = get_client_ip(request)
-        self.assertIsNone(ip)
-        self.assertFalse(routable)
+        assert ip is None
+        assert not routable
 
     def test_meta_single(self):
         request = HttpRequest()
@@ -22,7 +22,7 @@ class IPv4TestCase(TestCase):
             'HTTP_X_FORWARDED_FOR': '177.139.233.139, 198.84.193.157, 198.84.193.158',
         }
         result = get_client_ip(request)
-        self.assertEqual(result, ("177.139.233.139", True))
+        assert result == ('177.139.233.139', True)
 
     def test_meta_multi(self):
         request = HttpRequest()
@@ -31,7 +31,7 @@ class IPv4TestCase(TestCase):
             'REMOTE_ADDR': '177.139.233.133',
         }
         result = get_client_ip(request)
-        self.assertEqual(result, ("177.139.233.139", True))
+        assert result == ('177.139.233.139', True)
 
     def test_meta_multi_precedence_order(self):
         request = HttpRequest()
@@ -41,7 +41,7 @@ class IPv4TestCase(TestCase):
             'REMOTE_ADDR': '177.139.233.133',
         }
         result = get_client_ip(request)
-        self.assertEqual(result, ("177.139.233.139", True))
+        assert result == ('177.139.233.139', True)
 
     def test_meta_proxy_order_left_most(self):
         request = HttpRequest()
@@ -49,7 +49,7 @@ class IPv4TestCase(TestCase):
             'HTTP_X_FORWARDED_FOR': '177.139.233.139, 198.84.193.157, 198.84.193.158',
         }
         result = get_client_ip(request, proxy_order='left-most')
-        self.assertEqual(result, ("177.139.233.139", True))
+        assert result == ('177.139.233.139', True)
 
     def test_meta_proxy_order_right_most(self):
         request = HttpRequest()
@@ -57,7 +57,7 @@ class IPv4TestCase(TestCase):
             'HTTP_X_FORWARDED_FOR': '177.139.233.139, 198.84.193.157, 198.84.193.158',
         }
         result = get_client_ip(request, proxy_order='right-most')
-        self.assertEqual(result, ("198.84.193.158", True))
+        assert result == ('198.84.193.158', True)
 
     def test_meta_multi_precedence_private_first(self):
         request = HttpRequest()
@@ -67,7 +67,7 @@ class IPv4TestCase(TestCase):
             'REMOTE_ADDR': '177.139.233.133',
         }
         result = get_client_ip(request)
-        self.assertEqual(result, ("177.139.233.138", True))
+        assert result == ('177.139.233.138', True)
 
     def test_meta_multi_precedence_invalid_first(self):
         request = HttpRequest()
@@ -77,7 +77,7 @@ class IPv4TestCase(TestCase):
             'REMOTE_ADDR': '177.139.233.133',
         }
         result = get_client_ip(request)
-        self.assertEqual(result, ("177.139.233.138", True))
+        assert result == ('177.139.233.138', True)
 
     def test_meta_error_only(self):
         request = HttpRequest()
@@ -85,7 +85,7 @@ class IPv4TestCase(TestCase):
             'HTTP_X_FORWARDED_FOR': 'unknown, 177.139.233.139, 198.84.193.157, 198.84.193.158',
         }
         result = get_client_ip(request)
-        self.assertEqual(result, (None, False))
+        assert result == (None, False)
 
     def test_meta_error_first(self):
         request = HttpRequest()
@@ -94,7 +94,7 @@ class IPv4TestCase(TestCase):
             'X_FORWARDED_FOR': '177.139.233.138, 198.84.193.157, 198.84.193.158',
         }
         result = get_client_ip(request)
-        self.assertEqual(result, ("177.139.233.138", True))
+        assert result == ('177.139.233.138', True)
 
     def test_meta_singleton(self):
         request = HttpRequest()
@@ -102,7 +102,7 @@ class IPv4TestCase(TestCase):
             'HTTP_X_FORWARDED_FOR': '177.139.233.139',
         }
         result = get_client_ip(request)
-        self.assertEqual(result, ("177.139.233.139", True))
+        assert result == ('177.139.233.139', True)
 
     def test_meta_singleton_proxy_count(self):
         request = HttpRequest()
@@ -110,7 +110,7 @@ class IPv4TestCase(TestCase):
             'HTTP_X_FORWARDED_FOR': '177.139.233.139',
         }
         result = get_client_ip(request, proxy_count=1)
-        self.assertEqual(result, (None, False))
+        assert result == (None, False)
 
     def test_meta_singleton_proxy_count_private(self):
         request = HttpRequest()
@@ -119,7 +119,7 @@ class IPv4TestCase(TestCase):
             'HTTP_X_REAL_IP': '177.139.233.139',
         }
         result = get_client_ip(request, proxy_count=1)
-        self.assertEqual(result, (None, False))
+        assert result == (None, False)
 
     def test_meta_singleton_private_fallback(self):
         request = HttpRequest()
@@ -128,7 +128,7 @@ class IPv4TestCase(TestCase):
             'HTTP_X_REAL_IP': '177.139.233.139',
         }
         result = get_client_ip(request)
-        self.assertEqual(result, ("177.139.233.139", True))
+        assert result == ('177.139.233.139', True)
 
     def test_meta_proxy_trusted_ips_exact_ip_check(self):
         request = HttpRequest()
@@ -136,7 +136,7 @@ class IPv4TestCase(TestCase):
             'HTTP_X_FORWARDED_FOR': '177.139.233.139, 198.84.193.157, 198.84.193.158',
         }
         result = get_client_ip(request, proxy_trusted_ips=['198.84.193.158'])
-        self.assertEqual(result, ("177.139.233.139", True))
+        assert result == ('177.139.233.139', True)
 
     def test_meta_proxy_trusted_ips_exact_ips_check(self):
         request = HttpRequest()
@@ -144,7 +144,7 @@ class IPv4TestCase(TestCase):
             'HTTP_X_FORWARDED_FOR': '177.139.233.139, 198.84.193.157, 198.84.193.158',
         }
         result = get_client_ip(request, proxy_trusted_ips=['198.84.193.157', '198.84.193.158'])
-        self.assertEqual(result, ("177.139.233.139", True))
+        assert result == ('177.139.233.139', True)
 
     def test_meta_proxy_trusted_ips_subnet_start_with_check(self):
         request = HttpRequest()
@@ -152,7 +152,7 @@ class IPv4TestCase(TestCase):
             'HTTP_X_FORWARDED_FOR': '177.139.233.139, 198.84.193.157, 198.84.193.158',
         }
         result = get_client_ip(request, proxy_trusted_ips=['198.84.193'])
-        self.assertEqual(result, ("177.139.233.139", True))
+        assert result == ('177.139.233.139', True)
 
     def test_meta_proxy_trusted_ips_does_not_start_with_check(self):
         request = HttpRequest()
@@ -160,7 +160,7 @@ class IPv4TestCase(TestCase):
             'HTTP_X_FORWARDED_FOR': '177.139.233.139, 198.84.193.157, 198.84.193.158',
         }
         result = get_client_ip(request, proxy_trusted_ips=['84.193.158'])
-        self.assertEqual(result, (None, False))
+        assert result == (None, False)
 
     def test_meta_proxy_trusted_ips_proxy_count(self):
         request = HttpRequest()
@@ -168,7 +168,7 @@ class IPv4TestCase(TestCase):
             'HTTP_X_FORWARDED_FOR': '177.139.233.139, 198.84.193.157, 198.84.193.158',
         }
         result = get_client_ip(request, proxy_count=2, proxy_trusted_ips=['198.84.193.158'])
-        self.assertEqual(result, ("177.139.233.139", True))
+        assert result == ('177.139.233.139', True)
 
     def test_meta_proxy_trusted_ips_proxy_count_less_error(self):
         request = HttpRequest()
@@ -176,7 +176,7 @@ class IPv4TestCase(TestCase):
             'HTTP_X_FORWARDED_FOR': '177.139.233.139, 198.84.193.158',
         }
         result = get_client_ip(request, proxy_count=2, proxy_trusted_ips=['198.84.193.158'])
-        self.assertEqual(result, (None, False))
+        assert result == (None, False)
 
     def test_meta_proxy_trusted_ips_proxy_count_more_error(self):
         request = HttpRequest()
@@ -184,7 +184,7 @@ class IPv4TestCase(TestCase):
             'HTTP_X_FORWARDED_FOR': '177.139.233.139, 198.84.193.157, 198.84.193.158',
         }
         result = get_client_ip(request, proxy_count=1, proxy_trusted_ips=['198.84.193.158'])
-        self.assertEqual(result, (None, False))
+        assert result == (None, False)
 
     def test_meta_proxy_trusted_ips_proxy_count_more_error_fallback(self):
         request = HttpRequest()
@@ -193,7 +193,7 @@ class IPv4TestCase(TestCase):
             'HTTP_X_REAL_IP': '177.139.233.139',
         }
         result = get_client_ip(request, proxy_count=1, proxy_trusted_ips=['198.84.193.158'])
-        self.assertEqual(result, (None, False))
+        assert result == (None, False)
 
     def test_best_matched_ip(self):
         request = HttpRequest()
@@ -202,7 +202,7 @@ class IPv4TestCase(TestCase):
             'REMOTE_ADDR': '177.31.233.133',
         }
         ip = get_client_ip(request)
-        self.assertEqual(ip, ("177.31.233.133", True))
+        assert ip == ('177.31.233.133', True)
 
     def test_best_matched_ip_public(self):
         request = HttpRequest()
@@ -211,7 +211,7 @@ class IPv4TestCase(TestCase):
             'REMOTE_ADDR': '177.31.233.133',
         }
         ip = get_client_ip(request)
-        self.assertEqual(ip, ("177.31.233.122", True))
+        assert ip == ('177.31.233.122', True)
 
     def test_best_matched_ip_private(self):
         request = HttpRequest()
@@ -220,7 +220,7 @@ class IPv4TestCase(TestCase):
             'REMOTE_ADDR': '127.0.0.1',
         }
         ip = get_client_ip(request)
-        self.assertEqual(ip, ("192.168.1.1", False))
+        assert ip == ('192.168.1.1', False)
 
     def test_best_matched_ip_private_loopback_precedence(self):
         request = HttpRequest()
@@ -229,7 +229,7 @@ class IPv4TestCase(TestCase):
             'REMOTE_ADDR': '192.168.1.1',
         }
         ip = get_client_ip(request)
-        self.assertEqual(ip, ("192.168.1.1", False))
+        assert ip == ('192.168.1.1', False)
 
     def test_best_matched_ip_private_precedence(self):
         request = HttpRequest()
@@ -238,7 +238,7 @@ class IPv4TestCase(TestCase):
             'REMOTE_ADDR': '172.25.0.3',
         }
         ip = get_client_ip(request)
-        self.assertEqual(ip, ("172.25.0.3", False))
+        assert ip == ('172.25.0.3', False)
 
     def test_100_low_range_public(self):
         request = HttpRequest()
@@ -246,7 +246,7 @@ class IPv4TestCase(TestCase):
             'HTTP_X_REAL_IP': '100.63.0.9',
         }
         ip = get_client_ip(request)
-        self.assertEqual(ip, ("100.63.0.9", True))
+        assert ip == ('100.63.0.9', True)
 
     def test_100_block_private(self):
         request = HttpRequest()
@@ -254,7 +254,7 @@ class IPv4TestCase(TestCase):
             'HTTP_X_REAL_IP': '100.76.0.9',
         }
         ip = get_client_ip(request)
-        self.assertEqual(ip, ("100.76.0.9", False))
+        assert ip == ('100.76.0.9', False)
 
     def test_100_high_range_public(self):
         request = HttpRequest()
@@ -262,7 +262,7 @@ class IPv4TestCase(TestCase):
             'HTTP_X_REAL_IP': '100.128.0.9',
         }
         ip = get_client_ip(request)
-        self.assertEqual(ip, ("100.128.0.9", True))
+        assert ip == ('100.128.0.9', True)
 
     def test_request_header_order_specific(self):
         request = HttpRequest()
@@ -272,7 +272,7 @@ class IPv4TestCase(TestCase):
             'HTTP_X_FORWARDED_FOR': '177.139.233.139, 198.84.193.157, 198.84.193.158',
         }
         ip = get_client_ip(request, request_header_order=['HTTP_X_FORWARDED_FOR'])
-        self.assertEqual(ip, ("177.139.233.139", True))
+        assert ip == ('177.139.233.139', True)
 
 
     def test_request_header_order_multiple(self):
@@ -283,4 +283,4 @@ class IPv4TestCase(TestCase):
             'REMOTE_ADDR': '177.139.233.133',
         }
         ip = get_client_ip(request, request_header_order=['X_FORWARDED_FOR', 'HTTP_X_FORWARDED_FOR'])
-        self.assertEqual(ip, ("177.139.233.138", True))
+        assert ip == ('177.139.233.138', True)

--- a/ipware/tests/tests_ipv6.py
+++ b/ipware/tests/tests_ipv6.py
@@ -13,8 +13,8 @@ class IPv4TestCase(TestCase):
         request = HttpRequest()
         request.META = {}
         ip, routable = get_client_ip(request)
-        self.assertIsNone(ip)
-        self.assertFalse(routable)
+        assert ip is None
+        assert not routable
 
     def test_meta_single(self):
         request = HttpRequest()
@@ -22,7 +22,7 @@ class IPv4TestCase(TestCase):
             'HTTP_X_FORWARDED_FOR': '3ffe:1900:4545:3:200:f8ff:fe21:67cf, 74dc::02ba',
         }
         result = get_client_ip(request)
-        self.assertEqual(result, ("3ffe:1900:4545:3:200:f8ff:fe21:67cf", True))
+        assert result == ('3ffe:1900:4545:3:200:f8ff:fe21:67cf', True)
 
     def test_meta_multi(self):
         request = HttpRequest()
@@ -31,7 +31,7 @@ class IPv4TestCase(TestCase):
             'REMOTE_ADDR': '74dc::02bc',
         }
         result = get_client_ip(request)
-        self.assertEqual(result, ("3ffe:1900:4545:3:200:f8ff:fe21:67cf", True))
+        assert result == ('3ffe:1900:4545:3:200:f8ff:fe21:67cf', True)
 
     def test_meta_multi_precedence_order(self):
         request = HttpRequest()
@@ -41,7 +41,7 @@ class IPv4TestCase(TestCase):
             'REMOTE_ADDR': '74dc::02bc',
         }
         result = get_client_ip(request)
-        self.assertEqual(result, ("3ffe:1900:4545:3:200:f8ff:fe21:67cf", True))
+        assert result == ('3ffe:1900:4545:3:200:f8ff:fe21:67cf', True)
 
     def test_meta_proxy_order_left_most(self):
         request = HttpRequest()
@@ -49,7 +49,7 @@ class IPv4TestCase(TestCase):
             'HTTP_X_FORWARDED_FOR': '3ffe:1900:4545:3:200:f8ff:fe21:67cf, 74dc::02ba, 74dc::02bb',
         }
         result = get_client_ip(request, proxy_order='left-most')
-        self.assertEqual(result, ("3ffe:1900:4545:3:200:f8ff:fe21:67cf", True))
+        assert result == ('3ffe:1900:4545:3:200:f8ff:fe21:67cf', True)
 
     def test_meta_proxy_order_right_most(self):
         request = HttpRequest()
@@ -57,7 +57,7 @@ class IPv4TestCase(TestCase):
             'HTTP_X_FORWARDED_FOR': '3ffe:1900:4545:3:200:f8ff:fe21:67cf, 74dc::02ba, 74dc::02bb',
         }
         result = get_client_ip(request, proxy_order='right-most')
-        self.assertEqual(result, ("74dc::02bb", True))
+        assert result == ('74dc::02bb', True)
 
     def test_meta_multi_precedence_private_first(self):
         request = HttpRequest()
@@ -67,7 +67,7 @@ class IPv4TestCase(TestCase):
             'REMOTE_ADDR': '74dc::02bc',
         }
         result = get_client_ip(request)
-        self.assertEqual(result, ("3ffe:1900:4545:3:200:f8ff:fe21:67cf", True))
+        assert result == ('3ffe:1900:4545:3:200:f8ff:fe21:67cf', True)
 
     def test_meta_multi_precedence_invalid_first(self):
         request = HttpRequest()
@@ -77,7 +77,7 @@ class IPv4TestCase(TestCase):
             'REMOTE_ADDR': '74dc::02bc',
         }
         result = get_client_ip(request)
-        self.assertEqual(result, ("3ffe:1900:4545:3:200:f8ff:fe21:67cf", True))
+        assert result == ('3ffe:1900:4545:3:200:f8ff:fe21:67cf', True)
 
     def test_meta_error_only(self):
         request = HttpRequest()
@@ -85,7 +85,7 @@ class IPv4TestCase(TestCase):
             'X_FORWARDED_FOR': 'unknown, 3ffe:1900:4545:3:200:f8ff:fe21:67cf, 74dc::02ba, 74dc::02bb',
         }
         result = get_client_ip(request)
-        self.assertEqual(result, (None, False))
+        assert result == (None, False)
 
     def test_meta_error_first(self):
         request = HttpRequest()
@@ -94,7 +94,7 @@ class IPv4TestCase(TestCase):
             'X_FORWARDED_FOR': '3ffe:1900:4545:3:200:f8ff:fe21:67cf, 74dc::02ba, 74dc::02bb',
         }
         result = get_client_ip(request)
-        self.assertEqual(result, ("3ffe:1900:4545:3:200:f8ff:fe21:67cf", True))
+        assert result == ('3ffe:1900:4545:3:200:f8ff:fe21:67cf', True)
 
     def test_meta_singleton(self):
         request = HttpRequest()
@@ -102,7 +102,7 @@ class IPv4TestCase(TestCase):
             'HTTP_X_FORWARDED_FOR': '3ffe:1900:4545:3:200:f8ff:fe21:67cf',
         }
         result = get_client_ip(request)
-        self.assertEqual(result, ("3ffe:1900:4545:3:200:f8ff:fe21:67cf", True))
+        assert result == ('3ffe:1900:4545:3:200:f8ff:fe21:67cf', True)
 
     def test_meta_singleton_proxy_count(self):
         request = HttpRequest()
@@ -111,7 +111,7 @@ class IPv4TestCase(TestCase):
             'HTTP_X_REAL_IP': '74dc::02ba',
         }
         result = get_client_ip(request, proxy_count=1)
-        self.assertEqual(result, (None, False))
+        assert result == (None, False)
 
     def test_meta_singleton_proxy_count_private(self):
         request = HttpRequest()
@@ -120,7 +120,7 @@ class IPv4TestCase(TestCase):
             'HTTP_X_REAL_IP': '3ffe:1900:4545:3:200:f8ff:fe21:67cf',
         }
         result = get_client_ip(request, proxy_count=1)
-        self.assertEqual(result, (None, False))
+        assert result == (None, False)
 
     def test_meta_singleton_private_fallback(self):
         request = HttpRequest()
@@ -129,7 +129,7 @@ class IPv4TestCase(TestCase):
             'HTTP_X_REAL_IP': '3ffe:1900:4545:3:200:f8ff:fe21:67cf',
         }
         result = get_client_ip(request)
-        self.assertEqual(result, ("3ffe:1900:4545:3:200:f8ff:fe21:67cf", True))
+        assert result == ('3ffe:1900:4545:3:200:f8ff:fe21:67cf', True)
 
     def test_meta_proxy_trusted_ips(self):
         request = HttpRequest()
@@ -137,7 +137,7 @@ class IPv4TestCase(TestCase):
             'HTTP_X_FORWARDED_FOR': '3ffe:1900:4545:3:200:f8ff:fe21:67cf, 74dc::02ba, 74dc::02bb',
         }
         result = get_client_ip(request, proxy_trusted_ips=['74dc::02bb'])
-        self.assertEqual(result, ("3ffe:1900:4545:3:200:f8ff:fe21:67cf", True))
+        assert result == ('3ffe:1900:4545:3:200:f8ff:fe21:67cf', True)
 
     def test_meta_proxy_trusted_ips_proxy_count(self):
         request = HttpRequest()
@@ -145,7 +145,7 @@ class IPv4TestCase(TestCase):
             'HTTP_X_FORWARDED_FOR': '3ffe:1900:4545:3:200:f8ff:fe21:67cf, 74dc::02ba, 74dc::02bb',
         }
         result = get_client_ip(request, proxy_count=2, proxy_trusted_ips=['74dc::02bb'])
-        self.assertEqual(result, ("3ffe:1900:4545:3:200:f8ff:fe21:67cf", True))
+        assert result == ('3ffe:1900:4545:3:200:f8ff:fe21:67cf', True)
 
     def test_meta_proxy_trusted_ips_proxy_count_less_error(self):
         request = HttpRequest()
@@ -153,7 +153,7 @@ class IPv4TestCase(TestCase):
             'HTTP_X_FORWARDED_FOR': '3ffe:1900:4545:3:200:f8ff:fe21:67cf, 74dc::02bb',
         }
         result = get_client_ip(request, proxy_count=2, proxy_trusted_ips=['74dc::02bb'])
-        self.assertEqual(result, (None, False))
+        assert result == (None, False)
 
     def test_meta_proxy_trusted_ips_proxy_count_more_error(self):
         request = HttpRequest()
@@ -161,7 +161,7 @@ class IPv4TestCase(TestCase):
             'HTTP_X_FORWARDED_FOR': '3ffe:1900:4545:3:200:f8ff:fe21:67cf, 74dc::02ba, 74dc::02bb',
         }
         result = get_client_ip(request, proxy_count=1, proxy_trusted_ips=['74dc::02bb'])
-        self.assertEqual(result, (None, False))
+        assert result == (None, False)
 
     def test_meta_proxy_trusted_ips_proxy_count_more_error_ignore_fallback(self):
         request = HttpRequest()
@@ -170,7 +170,7 @@ class IPv4TestCase(TestCase):
             'HTTP_X_REAL_IP': '74dc::02bb',
         }
         result = get_client_ip(request, proxy_count=1, proxy_trusted_ips=['74dc::02bb'])
-        self.assertEqual(result, (None, False))
+        assert result == (None, False)
 
 
 class IPv6EncapsulationOfIPv4TestCase(TestCase):
@@ -182,7 +182,7 @@ class IPv6EncapsulationOfIPv4TestCase(TestCase):
             'HTTP_X_FORWARDED_FOR': '::ffff:127.0.0.1',
         }
         result = get_client_ip(request)
-        self.assertEqual(result, ('127.0.0.1', False))
+        assert result == ('127.0.0.1', False)
 
     def test_ipv6_encapsulation_of_ipv4_public(self):
         request = HttpRequest()
@@ -190,4 +190,4 @@ class IPv6EncapsulationOfIPv4TestCase(TestCase):
             'HTTP_X_FORWARDED_FOR': '::ffff:177.139.233.139',
         }
         result = get_client_ip(request)
-        self.assertEqual(result, ('177.139.233.139', True))
+        assert result == ('177.139.233.139', True)


### PR DESCRIPTION
% `ruff --select=PT009 --fix .`
```
Found 74 errors (74 fixed, 0 remaining).
```
When tests fail these simplifications enable pytest to show the `expected` and `actual` side-by-side.
* https://docs.pytest.org/en/7.2.x/how-to/assert.html
* https://docs.pytest.org/en/7.2.x/how-to/assert.html#assert-details