### PR TITLE
Add HTTP_X_CLIENT_IP to defaults.py

### DIFF
--- a/ipware/defaults.py
+++ b/ipware/defaults.py
@@ -14,6 +14,7 @@ IPWARE_META_PRECEDENCE_ORDER = getattr(settings,
         'HTTP_FORWARDED_FOR',
         'HTTP_FORWARDED',
         'HTTP_VIA',
+        'HTTP_X_CLIENT_IP",
         'REMOTE_ADDR',
     )
 )

--- a/ipware/defaults.py
+++ b/ipware/defaults.py
@@ -14,7 +14,7 @@ IPWARE_META_PRECEDENCE_ORDER = getattr(settings,
         'HTTP_FORWARDED_FOR',
         'HTTP_FORWARDED',
         'HTTP_VIA',
-        'HTTP_X_CLIENT_IP",
+        'HTTP_X_CLIENT_IP',
         'REMOTE_ADDR',
     )
 )


### PR DESCRIPTION
`X-Client-Ip` is used by Azure. Seems worthwhile to add it.

Worth mentioning that the already present keys, like `HTTP_X_FORWARDED_FOR` and `HTTP_CLIENT_IP` do return a value, but it's in the form of `ip:port`, which fails the `is_valid_ip` validation. I've thought about creating a PR that would strip the port if a given new setting was set to True. 

I've eventually decided against it, as it seems a bit intrusive and because the sole ip address is still present in the META, so it wasn't really necessary.

Lmk what you think.