### PR TITLE
Add Python 3.12 and Django v5.0 to testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10", "3.11", "3.12"]
-        django-version: [3.2, 4.1, 4.2, 5.0rc1]
+        python-version: [3.8, 3.9, "3.10", 3.11, 3.12]
+        django-version: [3.2, 4.1, 4.2, "5.0"]
         exclude:
           # excludes list
           - python-version: 3.11
@@ -32,6 +32,10 @@ jobs:
             django-version: 4.1
           - python-version: 3.12
             django-version: 4.2
+          - python-version: 3.8
+            django-version: 5.0
+          - python-version: 3.9
+            django-version: 5.0
 
     steps:
       - uses: actions/checkout@v4
@@ -46,7 +50,7 @@ jobs:
           pip install --upgrade coveralls ruff
           pip install "django~=${{ matrix.django-version }}"
       - name: Run ruff
-        run: ruff .
+        run: ruff --output-format=github
       - name: Run test
         run: coverage run --source=ipware manage.py test
       - name: Coveralls

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.8, 3.9, "3.10", "3.11", "3.12"]
-        django-version: [3.2, 4.1, 4.2, "5.0"]
+        django-version: [3.2, 4.1, 4.2, 5.0rc1]
         exclude:
           # excludes list
           - python-version: 3.11

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,6 @@ jobs:
             django-version: 3.2
           - python-version: 3.12
             django-version: 4.1
-          - python-version: 3.12
-            django-version: 4.2
           - python-version: 3.8
             django-version: 5.0
           - python-version: 3.9

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,15 +21,13 @@ jobs:
     strategy:
       matrix:
         python-version: [3.8, 3.9, "3.10", "3.11", "3.12"]
-        django-version: [3.2, 4.1, 4.2, 5.0]
+        django-version: [3.2, 4.1, 4.2, "5.0"]
         exclude:
           # excludes list
           - python-version: 3.11
             django-version: 3.2
           - python-version: 3.12
             django-version: 3.2
-          - python-version: 3.12
-            django-version: 4.0
           - python-version: 3.12
             django-version: 4.1
           - python-version: 3.12

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,15 +20,23 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10", "3.11"]
-        django-version: [3.2, 4.1, 4.2]
+        python-version: [3.8, 3.9, "3.10", "3.11", "3.12"]
+        django-version: [3.2, 4.1, 4.2, 5.0]
         exclude:
           # excludes list
           - python-version: 3.11
             django-version: 3.2
+          - python-version: 3.12
+            django-version: 3.2
+          - python-version: 3.12
+            django-version: 4.0
+          - python-version: 3.12
+            django-version: 4.1
+          - python-version: 3.12
+            django-version: 4.2
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: setup python
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
https://pypi.org/project/Django

https://www.djangoproject.com/weblog/2023/dec/04/django-50-released

Django 4.1 has reached the end of extended support. The final security release ([4.1.13](https://docs.djangoproject.com/en/stable/releases/4.1.13/)) was issued on November 1st. All Django 4.1 users are encouraged to [upgrade](https://docs.djangoproject.com/en/dev/howto/upgrade-version/) to Django 4.2 or later.

https://docs.djangoproject.com/en/5.0/releases/5.0
> Django 5.0 supports Python 3.10, 3.11, and 3.12.