### PR TITLE
[FEAT] -- Add IPBanlistMiddleware and IPAllowlistMiddleware with test cases.

### DIFF
--- a/ipware/middleware.py
+++ b/ipware/middleware.py
@@ -1,0 +1,70 @@
+import logging
+
+from django.conf import settings
+from django.core.exceptions import PermissionDenied
+
+from .ip import get_client_ip
+
+# Initialize logger
+logger = logging.getLogger(__name__)
+
+
+class IPBanlistMiddleware:
+    """
+    Middleware to block requests from IPs listed in `settings.BANNED_IPS`.
+
+    Usage:
+    Add 'ipware.middleware.IPBanlistMiddleware' to MIDDLEWARE in your Django settings.py.
+    Define `BANNED_IPS` in your Django settings.py as a list of blocked IP addresses.
+
+    Example:
+    BANNED_IPS = ["192.168.1.100", "10.0.0.1"]
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        banned_ips = getattr(settings, "BANNED_IPS", [])
+
+        if not isinstance(banned_ips, (list, tuple)):
+            raise ValueError("BANNED_IPS must be a list or tuple of IP addresses.")
+
+        client_ip, _ = get_client_ip(request)
+
+        if client_ip in banned_ips:
+            logger.warning(f"Blocked IP attempt: {client_ip}")
+            raise PermissionDenied("Your IP address is banned.")
+
+        return self.get_response(request)
+
+
+class IPAllowlistMiddleware:
+    """
+    Middleware to allow access only to IPs listed in `settings.ALLOWED_IPS`.
+
+    Usage:
+    Add 'ipware.middleware.IPAllowlistMiddleware' to MIDDLEWARE in your Django settings.py.
+    Define `ALLOWED_IPS` in your Django settings.py as a list of allowed IP addresses.
+    If `ALLOWED_IPS` is not defined or None, no IP restrictions are applied.
+
+    Example:
+    ALLOWED_IPS = ["203.0.113.42", "198.51.100.24"]
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        allowed_ips = getattr(settings, "ALLOWED_IPS", None)
+
+        if allowed_ips is not None and not isinstance(allowed_ips, (list, tuple)):
+            raise ValueError("ALLOWED_IPS must be a list or tuple of IP addresses.")
+
+        client_ip, _ = get_client_ip(request)
+
+        if allowed_ips is not None and client_ip not in allowed_ips:
+            logger.warning(f"Unauthorized access attempt from IP: {client_ip}")
+            raise PermissionDenied("Your IP address is not allowed.")
+
+        return self.get_response(request)

--- a/ipware/tests/tests_middleware.py
+++ b/ipware/tests/tests_middleware.py
@@ -1,0 +1,131 @@
+# -*- coding: utf-8 -*-
+
+from django.core.exceptions import PermissionDenied
+from django.http import HttpRequest
+from django.test import TestCase, override_settings
+
+from ipware.middleware import IPBanlistMiddleware, IPAllowlistMiddleware
+
+
+class TestIPBanlistMiddleware(TestCase):
+    """Test cases for IPBanlistMiddleware"""
+
+    def setUp(self):
+        # Create a mock response function for the middleware
+        self.get_response = lambda request: None
+        # Create an instance of the middleware
+        self.middleware = IPBanlistMiddleware(self.get_response)
+
+    @override_settings(BANNED_IPS=["192.168.1.100"])
+    def test_banned_ip_blocked(self):
+        """Test that a request from a banned IP raises PermissionDenied."""
+        request = HttpRequest()
+        request.META = {
+            "REMOTE_ADDR": "192.168.1.100",
+            "HTTP_X_FORWARDED_FOR": "192.168.1.100, 198.84.193.157",
+        }
+        with self.assertRaises(PermissionDenied) as context:
+            self.middleware(request)
+        self.assertEqual(str(context.exception), "Your IP address is banned.")
+
+    @override_settings(BANNED_IPS=["192.168.1.100"])
+    def test_allowed_ip_not_blocked(self):
+        """Test that a request from a non-banned IP passes through."""
+        request = HttpRequest()
+        request.META = {
+            "REMOTE_ADDR": "10.0.0.1",
+            "HTTP_X_FORWARDED_FOR": "10.0.0.1, 198.84.193.157",
+        }
+        result = self.middleware(request)
+        self.assertIsNone(result)  # Request should pass to next middleware
+
+    @override_settings(BANNED_IPS=[])
+    def test_no_banned_ips_setting(self):
+        """Test that no blocking occurs if BANNED_IPS is empty."""
+        request = HttpRequest()
+        request.META = {
+            "REMOTE_ADDR": "192.168.1.100",
+            "HTTP_X_FORWARDED_FOR": "192.168.1.100, 198.84.193.157",
+        }
+        result = self.middleware(request)
+        self.assertIsNone(result)  # No blocking, request passes through
+
+    @override_settings(BANNED_IPS="not_a_list_or_tuple")
+    def test_invalid_banned_ips_setting(self):
+        """Test that an invalid BANNED_IPS setting raises ValueError."""
+        request = HttpRequest()
+        request.META = {
+            "REMOTE_ADDR": "192.168.1.100",
+            "HTTP_X_FORWARDED_FOR": "192.168.1.100, 198.84.193.157",
+        }
+        with self.assertRaises(ValueError) as context:
+            self.middleware(request)
+        self.assertEqual(str(context.exception), "BANNED_IPS must be a list or tuple of IP addresses.")
+
+
+class TestIPAllowlistMiddleware(TestCase):
+    """Test cases for IPAllowlistMiddleware"""
+
+    def setUp(self):
+        # Create a mock response function for the middleware
+        self.get_response = lambda request: None
+        # Create an instance of the middleware
+        self.middleware = IPAllowlistMiddleware(self.get_response)
+
+    @override_settings(ALLOWED_IPS=["203.0.113.42"])
+    def test_allowed_ip_permitted(self):
+        """Test that a request from an allowed IP passes through."""
+        request = HttpRequest()
+        request.META = {
+            "REMOTE_ADDR": "203.0.113.42",
+            "HTTP_X_FORWARDED_FOR": "203.0.113.42, 198.84.193.157",
+        }
+        result = self.middleware(request)
+        self.assertIsNone(result)  # Request should pass to next middleware
+
+    @override_settings(ALLOWED_IPS=["203.0.113.42"])
+    def test_not_allowed_ip_blocked(self):
+        """Test that a request from a non-allowed IP raises PermissionDenied."""
+        request = HttpRequest()
+        request.META = {
+            "REMOTE_ADDR": "192.168.1.100",
+            "HTTP_X_FORWARDED_FOR": "192.168.1.100, 198.84.193.157",
+        }
+        with self.assertRaises(PermissionDenied) as context:
+            self.middleware(request)
+        self.assertEqual(str(context.exception), "Your IP address is not allowed.")
+
+    @override_settings(ALLOWED_IPS=None)
+    def test_no_allowed_ips_setting(self):
+        """Test that no restrictions apply if ALLOWED_IPS is set to `None`."""
+        request = HttpRequest()
+        request.META = {
+            "REMOTE_ADDR": "192.168.1.100",
+            "HTTP_X_FORWARDED_FOR": "192.168.1.100, 198.84.193.157",
+        }
+        result = self.middleware(request)
+        self.assertIsNone(result)  # No restrictions, request passes through
+
+    @override_settings(ALLOWED_IPS=[])
+    def test_empty_allowed_ips_setting(self):
+        """Test that a request with an empty ALLOWED_IPS list raises PermissionDenied."""
+        request = HttpRequest()
+        request.META = {
+            "REMOTE_ADDR": "192.168.1.100",
+            "HTTP_X_FORWARDED_FOR": "192.168.1.100, 198.84.193.157",
+        }
+        with self.assertRaises(PermissionDenied) as context:
+            self.middleware(request)
+        self.assertEqual(str(context.exception), "Your IP address is not allowed.")
+
+    @override_settings(ALLOWED_IPS="not_a_list_or_tuple")
+    def test_invalid_allowed_ips_setting(self):
+        """Test that an invalid ALLOWED_IPS setting raises ValueError."""
+        request = HttpRequest()
+        request.META = {
+            "REMOTE_ADDR": "203.0.113.42",
+            "HTTP_X_FORWARDED_FOR": "203.0.113.42, 198.84.193.157",
+        }
+        with self.assertRaises(ValueError) as context:
+            self.middleware(request)
+        self.assertEqual(str(context.exception), "ALLOWED_IPS must be a list or tuple of IP addresses.")


### PR DESCRIPTION
# Description

This pull request introduces new middleware classes, `IPBanlistMiddleware` and `IPAllowlistMiddleware`, to `middleware.py` in `django-ipware`. These classes enhance Django applications with IP-based access control, allowing developers to block requests from banned IPs or restrict access to only allowed IPs using the existing `get_client_ip` functionality from `django-ipware`.

- `IPBanlistMiddleware` blocks requests from IPs listed in `settings.BANNED_IPS`, preventing unauthorized access from known malicious or restricted IPs.
- `IPAllowlistMiddleware` restricts access to only IPs listed in `settings.ALLOWED_IPS`, ensuring only trusted IPs can interact with the application, and raises `PermissionDenied` for unauthorized access while logging warnings for blocked attempts.

# How It Works

- **IPBanlistMiddleware**: Prevents access from IPs specified in `settings.BANNED_IPS`, safeguarding against unauthorized or malicious traffic.
- **IPAllowlistMiddleware**: Permits access exclusively to IPs listed in `settings.ALLOWED_IPS`, enhancing security by limiting access to trusted sources.

# How to Use

Follow these steps to integrate the middleware into your Django project:

1. **Add the Middleware** to your Django `settings.py` `MIDDLEWARE` setting:
   - For `IPBanlistMiddleware`:
     #### Using IPBanlistMiddleware
     ```python
     MIDDLEWARE = [
         ...,
         'ipware.middleware.IPBanlistMiddleware',
         ...
     ]
     ```
   - For `IPAllowlistMiddleware`:
     #### Using IPAllowlistMiddleware
     ```python
     MIDDLEWARE = [
         ...,
         'ipware.middleware.IPAllowlistMiddleware',
         ...
     ]
     ```
   ***Note***: These middleware classes are typically used separately, as they serve opposite purposes (banning vs. allowing IPs).

2. **Define Settings Variables** in your Django `settings.py`:
   - **BANNED_IPS**: A list of IP addresses to block, used by `IPBanlistMiddleware`.
     ```python
     BANNED_IPS = ["192.168.1.100", "10.0.0.1"]
     ```
   - **ALLOWED_IPS**: A list of IP addresses to allow, used by `IPAllowlistMiddleware`. If not defined or set to `None`, no restrictions are applied.
     ```python
     ALLOWED_IPS = ["203.0.113.42", "198.51.100.24"]
     ```

The middleware seamlessly integrates with `ipware.ip.get_client_ip` to retrieve client IPs and enforce access control, providing robust security for Django applications.

# Tests

New test cases have been added in `tests/tests_middleware.py` to thoroughly validate the functionality of both middleware classes. The tests cover:
- Blocking and allowing requests based on `BANNED_IPS` and `ALLOWED_IPS` settings.
- Handling edge cases, such as empty, `None`, or undefined settings (default behavior).
- Validating that invalid settings (e.g., non-list/tuple values) raise `ValueError`.
- Ensuring proper `PermissionDenied` exceptions and logging for blocked attempts.

![Successful Test Cases](https://github.com/user-attachments/assets/5e622ba0-6e3f-4584-830d-9eddd8549afe)

# Task List

- [x] Added test cases
- [ ] Updated GitHub README