### PR TITLE
Include py.typed in package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
     author_email=about['__author_email__'],
     url=about['__url__'],
     packages=[package],
-    package_data={'': ['LICENSE']},
+    package_data={'': ['py.typed', 'LICENSE']},
     package_dir={'ipware': 'ipware'},
     include_package_data=True,
     python_requires=python_requires,


### PR DESCRIPTION
This helps type checkers identify that imports from `ipware` are typed so that untyped imports do not need to be ignored for statements like:

```py
from ipware import get_client_ip
```

```grep
utils/http.py:8: error: Skipping analyzing "ipware": module is installed, but missing library stubs or py.typed marker  [import-untyped]
utils/http.py:8: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
```