### PR TITLE
Test against currently supported Python and Django versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,20 +20,18 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10", 3.11, 3.12]
-        django-version: [3.2, 4.1, 4.2, "5.0"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        django-version: ["4.2", "5.2", "6.0"]
         exclude:
           # excludes list
-          - python-version: 3.11
-            django-version: 3.2
-          - python-version: 3.12
-            django-version: 3.2
-          - python-version: 3.12
-            django-version: 4.1
-          - python-version: 3.8
-            django-version: 5.0
-          - python-version: 3.9
-            django-version: 5.0
+          - python-version: "3.13"
+            django-version: "4.2"
+          - python-version: "3.14"
+            django-version: "4.2"
+          - python-version: "3.10"
+            django-version: "6.0"
+          - python-version: "3.11"
+            django-version: "6.0"
 
     steps:
       - uses: actions/checkout@v4
@@ -48,7 +46,7 @@ jobs:
           pip install --upgrade coveralls ruff
           pip install "django~=${{ matrix.django-version }}"
       - name: Run ruff
-        run: ruff --output-format=github
+        run: ruff check --output-format=github
       - name: Run test
         run: coverage run --source=ipware manage.py test
       - name: Coveralls

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Unreleased
+
+Enhancement:
+- Added support for Django 5.2 and Django 6.0.
+- Added support for Python 3.13 and Python 3.14.
+- Dropped support for Django 3.2, Django 4.1, and Django 5.0.
+- Dropped support for Python 3.8 and Python 3.9
+
 # 7.0.0 / 7.0.1
 
 Enhance:

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from shutil import rmtree
 from setuptools import setup
 
 package = 'ipware'
-python_requires = ">=3.8"
+python_requires = ">=3.10"
 here = os.path.abspath(os.path.dirname(__file__))
 
 requires = ['python-ipware>=2.0.3']
@@ -69,11 +69,14 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14',
+        'Framework :: Django :: 4.2',
+        'Framework :: Django :: 5.2',
+        'Framework :: Django :: 6.0',
     ],
     cmdclass={},
     tests_require=test_requirements,


### PR DESCRIPTION
This updates the CI test matrix to test against the currently supported set of Python and Django versions. It also fixes an issue where `ruff` wouldn't run in CI anymore.